### PR TITLE
Regularisation of Functionals

### DIFF
--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -1,6 +1,6 @@
 import ROL
 import firedrake as fd
-from .control import ControlSpace, ControlVector
+from .control import ControlSpace, ControlVector, FeMultiGridControlSpace
 from .pde_constraint import PdeConstraint
 
 

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -169,3 +169,24 @@ class ReducedObjective(Objective):
         self.e.solve_adjoint(self.J.scale * self.J.value_form())
         if iteration > 0 and self.cb is not None:
             self.cb()
+
+
+class ObjectiveSum(ROL.Objective):
+
+    def __init__(self, a, b):
+        super().__init__()
+        self.a = a
+        self.b = b
+
+    def value(self, x, tol):
+        return self.a.value(x, tol) + self.b.value(x, tol)
+
+    def gradient(self, g, x, tol):
+        temp = g.clone()
+        self.a.gradient(g, x, tol)
+        self.b.gradient(temp, x, tol)
+        g.plus(temp)
+
+    def update(self, *args):
+        self.a.update(*args)
+        self.b.update(*args)

--- a/fireshape/zoo/__init__.py
+++ b/fireshape/zoo/__init__.py
@@ -1,3 +1,4 @@
 from .levelset_functional import *
 from .fluid_solvers import *
 from .fluid_objectives import *
+from .box_constraint import *

--- a/fireshape/zoo/__init__.py
+++ b/fireshape/zoo/__init__.py
@@ -3,3 +3,4 @@ from .fluid_solvers import *
 from .fluid_objectives import *
 from .box_constraint import *
 from .spectral_constraint import *
+from .deformation_regularization import *

--- a/fireshape/zoo/__init__.py
+++ b/fireshape/zoo/__init__.py
@@ -2,3 +2,4 @@ from .levelset_functional import *
 from .fluid_solvers import *
 from .fluid_objectives import *
 from .box_constraint import *
+from .spectral_constraint import *

--- a/fireshape/zoo/box_constraint.py
+++ b/fireshape/zoo/box_constraint.py
@@ -1,0 +1,66 @@
+import firedrake as fd
+import fireshape as fs
+# import numpy as np
+# from numpy.linalg import svd
+
+
+__all__ = ["MoYoBoxConstraint"]
+
+
+def Min(a, b): return (a+b-abs(a-b))/fd.Constant(2)
+
+
+def Max(a, b): return (a+b+abs(a-b))/fd.Constant(2)
+
+
+class MoYoBoxConstraint(fs.DeformationObjective):
+
+    def __init__(self, c, bids, *args, lower_bound=None,
+                 upper_bound=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.T = self.Q.T
+        self.lam = fd.Function(self.T.function_space())
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        self.bids = bids
+        self.viol = fd.Function(self.T.function_space())
+        self.c = c
+
+    def value_form(self):
+        lam = self.lam
+        # lamv = lam.vector()
+        c = self.c
+        psi = self.upper_bound
+        phi = self.lower_bound
+        T = self.T
+        # Tv = T.vector()
+        temp0 = Max(lam[0] + c*(T[0]-psi[0]), fd.Constant(0.0)) \
+            + Min(lam[0] + c*(T[0]-phi[0]), fd.Constant(0.0))
+        temp1 = Max(lam[1] + c*(T[1]-psi[1]), fd.Constant(0.0)) \
+            + Min(lam[1] + c*(T[1]-phi[1]), fd.Constant(0.0))
+        val = (1.0/(2.0*c)) * (self.dot(temp0, temp0)+self.dot(temp1, temp1)
+                               - self.dot(lam, lam))
+        return val
+
+    def derivative_form(self, test):
+        T = self.T
+        return fd.derivative(self.value_form(), T, test)
+
+    def dot(self, u, v):
+        return sum([fd.inner(u, v)*fd.ds(bid) for bid in self.bids])
+
+
+def RelevantPartOfVector(vec, maximum, compare=0.0):
+    relvec = vec.copy()
+    comparevec = vec.copy()
+    relvec *= 0
+    from firedrake import as_backend_type
+    pvec = as_backend_type(vec).vec()
+    pcomparevec = as_backend_type(comparevec).vec()
+    pcomparevec.set(compare)
+    prelvec = as_backend_type(relvec).vec()
+    if maximum:
+        prelvec.pointwiseMax(pcomparevec, pvec)
+    else:
+        prelvec.pointwiseMin(pcomparevec, pvec)
+    return relvec

--- a/fireshape/zoo/box_constraint.py
+++ b/fireshape/zoo/box_constraint.py
@@ -1,7 +1,5 @@
 import firedrake as fd
 import fireshape as fs
-# import numpy as np
-# from numpy.linalg import svd
 
 
 __all__ = ["MoYoBoxConstraint"]

--- a/fireshape/zoo/deformation_regularization.py
+++ b/fireshape/zoo/deformation_regularization.py
@@ -1,0 +1,56 @@
+import firedrake as fd
+import fireshape as fs
+
+
+__all__ = ["DeformationRegularization", "CoarseDeformationRegularization"]
+
+
+class DeformationRegularization(fs.DeformationObjective):
+
+    def __init__(self, *args, l2_reg=1., sym_grad_reg=1., skew_grad_reg=1., **kwargs):
+        super().__init__(*args, **kwargs)
+        self.T = self.Q.T
+        self.id = self.T.copy(deepcopy=True)
+        self.id.interpolate(fd.SpatialCoordinate(self.T.ufl_domain()))
+        self.l2_reg = l2_reg
+        self.sym_grad_reg = sym_grad_reg
+        self.skew_grad_reg = skew_grad_reg
+
+    def value_form(self):
+        f = self.T-self.id
+        norm = lambda u: fd.inner(u, u) * fd.dx
+        val = self.l2_reg * norm(f)
+        val += self.sym_grad_reg * norm(fd.sym(fd.grad(f)))
+        val += self.skew_grad_reg * norm(fd.skew(fd.grad(f)))
+        return val
+
+    def derivative_form(self, test):
+        T = self.T
+        return fd.derivative(self.value_form(), T, test)
+
+
+class CoarseDeformationRegularization(fs.MultigridCoarseDeformationObjective):
+
+    def __init__(self, *args, l2_reg=1., sym_grad_reg=1., skew_grad_reg=1., **kwargs):
+        super().__init__(*args, **kwargs)
+        self.f = fd.Function(self.Q.V_r_coarse)
+        self.l2_reg = l2_reg
+        self.sym_grad_reg = sym_grad_reg
+        self.skew_grad_reg = skew_grad_reg
+
+    def value_form(self):
+        f = self.f
+        norm = lambda u: fd.inner(u, u) * fd.dx
+        val = self.l2_reg * norm(f)
+        val += self.sym_grad_reg * norm(fd.sym(fd.grad(f)))
+        val += self.skew_grad_reg * norm(fd.skew(fd.grad(f)))
+        return val
+
+    def derivative_form(self, test):
+        f = self.f
+        deriv = fd.derivative(self.value_form(), f, test)
+        return deriv
+    
+    def update(self, x, flag, iteration):
+        self.f.assign(x.fun)
+        super().update(x, flag, iteration)

--- a/fireshape/zoo/fluid_objectives.py
+++ b/fireshape/zoo/fluid_objectives.py
@@ -1,10 +1,10 @@
 import firedrake as fd
-from ..objective import Objective
+from ..objective import ShapeObjective
 from .fluid_solvers import FluidSolver, StokesSolver
 __all__ = ["EnergyObjective"]
 
 
-class EnergyObjective(Objective):
+class EnergyObjective(ShapeObjective):
     """Energy functional for fluid problems."""
     def __init__(self, pde_solver: FluidSolver, *args,  **kwargs):
         super().__init__(*args, **kwargs)

--- a/fireshape/zoo/levelset_functional.py
+++ b/fireshape/zoo/levelset_functional.py
@@ -1,11 +1,11 @@
 import firedrake as fd
-from ..objective import Objective
+from ..objective import ShapeObjective
 
 
 __all__ = ["LevelsetFunctional"]
 
 
-class LevelsetFunctional(Objective):
+class LevelsetFunctional(ShapeObjective):
     """
     Implementation of level-set shape functional.
 

--- a/fireshape/zoo/spectral_constraint.py
+++ b/fireshape/zoo/spectral_constraint.py
@@ -25,10 +25,8 @@ class MoYoSpectralConstraint(fs.DeformationObjective):
 
         self.iden = fd.Function(self.V_r)
         self.iden.interpolate(fd.SpatialCoordinate(r_mesh))
-        # from firedrake import File
-        # self.lam_file = File("lam.pvd")
         self.S = self.T.copy(deepcopy=True)
-        self.dim = r_mesh.geometric_dimension()
+        self.dim = r_mesh.topological_dimension()
 
     def update_state(self):
         lam = self.lam

--- a/fireshape/zoo/spectral_constraint.py
+++ b/fireshape/zoo/spectral_constraint.py
@@ -1,0 +1,83 @@
+import firedrake as fd
+import fireshape as fs
+import numpy as np
+from numpy.linalg import svd
+
+__all__ = ["MoYoSpectralConstraint"]
+
+
+class MoYoSpectralConstraint(fs.DeformationObjective):
+
+    def __init__(self, c, bound, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.c = c
+        self.T = self.Q.T
+        r_mesh = self.T.ufl_domain()
+        self.lam_space = fd.TensorFunctionSpace(r_mesh, "DG", 0)
+        self.scalar_space = fd.FunctionSpace(r_mesh, "DG", 0)
+        self.nuclear_norm = fd.Function(self.scalar_space)
+        self.viol = fd.Function(self.scalar_space)
+        self.lam = fd.Function(self.lam_space)
+        self.gradS = fd.Function(self.lam_space)
+        self.lam_c_grad_S = fd.Function(self.lam_space)
+        self.argmin = fd.Function(self.lam_space)
+        self.bound = fd.Function(self.scalar_space).interpolate(bound)
+
+        self.iden = fd.Function(self.V_r)
+        self.iden.interpolate(fd.SpatialCoordinate(r_mesh))
+        # from firedrake import File
+        # self.lam_file = File("lam.pvd")
+        self.S = self.T.copy(deepcopy=True)
+        self.dim = r_mesh.geometric_dimension()
+
+    def update_state(self):
+        lam = self.lam
+        c = self.c
+        av = self.bound.vector()[:]
+        self.S.assign(self.T)
+        self.S -= self.iden
+        S = self.S
+        self.gradS.project(fd.grad(S))
+        lam_c_grad_S = self.lam_c_grad_S
+        lam_c_grad_S.project(lam/c + self.gradS)
+        lam_c_grad_Sv = lam_c_grad_S.vector()
+        B = self.argmin.vector()[:].copy()
+        nucv = self.nuclear_norm.vector()[:].copy()
+        for i in range(len(lam_c_grad_Sv)):
+            W, Sigma, V = svd(lam_c_grad_Sv[i], full_matrices=False)
+            for j in range(self.dim):
+                Sigma[j] = c * max(Sigma[j]-av[i], 0)
+            B[i] = np.dot(W, np.dot(np.diag(Sigma), V))
+            nucv[i] = av[i]*np.sum(Sigma)
+        self.argmin.vector().set_local(B.flatten())
+        self.nuclear_norm.vector().set_local(nucv.flatten())
+
+    def value_form(self):
+        self.update_state()
+        val = fd.inner(self.gradS, self.argmin) * fd.dx \
+            - self.nuclear_norm * fd.dx \
+            - (0.5/self.c) * fd.inner(self.argmin - self.lam,
+                                      self.argmin - self.lam) * fd.dx
+        return val
+
+    def derivative_form(self, test):
+        self.update_state()
+        return fd.inner(self.argmin, fd.grad(test))*fd.dx
+
+    def update_multiplier(self, stepsize=1.0):
+        lam = self.lam
+        lam *= (1-stepsize)
+        lam += stepsize * self.argmin
+        self.update_state()
+
+    def violation(self):
+        gradSv = self.gradS.vector()[:]
+        av = self.upper_bound.vector()[:]
+        violv = self.viol.vector()[:].copy()
+        for i in range(len(gradSv)):
+            W, Sigma, V = svd(gradSv[i], full_matrices=False)
+            for j in range(self.dim):
+                Sigma[j] = max(Sigma[j]-av[i], 0)**2
+            violv[i] = self.c * 0.5 * np.sum(Sigma)
+        self.viol.vector().set_local(violv.flatten())
+        return fd.sqrt(fd.assemble(self.viol*fd.dx))

--- a/tests/test_adding_regularization.py
+++ b/tests/test_adding_regularization.py
@@ -1,0 +1,52 @@
+import pytest
+import firedrake as fd
+import fireshape as fs
+import fireshape.zoo as fsz
+
+import ROL
+
+def test_taylor_tests():
+    n = 5
+    mesh = fd.UnitSquareMesh(n, n)
+    inner = fs.LaplaceInnerProduct()
+    Q = fs.FeMultiGridControlSpace(mesh, inner, refinements=1, order=1)
+    mesh_m = Q.mesh_m
+
+    q = fs.ControlVector(Q)
+
+    X = fd.SpatialCoordinate(mesh)
+    q.fun.interpolate(0.5 * X)
+
+
+    lower_bound = Q.T.copy(deepcopy=True)
+    lower_bound.interpolate(fd.Constant((-0.0, -0.0)))
+    upper_bound = Q.T.copy(deepcopy=True)
+    upper_bound.interpolate(fd.Constant((+1.3, +0.9)))
+
+    J1 = fsz.MoYoBoxConstraint(1, [1, 2, 3, 4], Q,
+                               lower_bound=lower_bound,
+                               upper_bound=upper_bound)
+    J2 = fsz.MoYoSpectralConstraint(1, fd.Constant(0.2), Q)
+    J3 = fsz.DeformationRegularization(Q, l2_reg=.1, sym_grad_reg=1.,
+                                       skew_grad_reg=.5)
+    J4 = fsz.CoarseDeformationRegularization(Q, l2_reg=.1, sym_grad_reg=1.,
+                                             skew_grad_reg=.5)
+    
+
+    Js = 0.1 * J1 + J2 + 2. * (J3 + J4)
+    g = q.clone()
+
+    def run_taylor_test(J):
+        J.update(q, None, 1)
+        J.gradient(g, q, None)
+        return J.checkGradient(q, g, 8, 1)
+
+    def check_result(test_result):
+        for i in range(len(test_result)-1):
+            assert test_result[i+1][3] <= test_result[i][3] * 0.11
+
+    check_result(run_taylor_test(J1))
+    check_result(run_taylor_test(J2))
+    check_result(run_taylor_test(J3))
+    check_result(run_taylor_test(J4))
+    check_result(run_taylor_test(Js))

--- a/tests/test_box_constraints.py
+++ b/tests/test_box_constraints.py
@@ -1,0 +1,70 @@
+import unittest
+import firedrake as fd
+import fireshape as fs
+import fireshape.zoo as fsz
+import numpy as np
+
+import ROL
+
+
+def test_box_constraint(pytestconfig):
+
+    n = 5
+    mesh = fd.UnitSquareMesh(n, n)
+    T = mesh.coordinates.copy(deepcopy=True)
+    (x, y) = fd.SpatialCoordinate(mesh)
+    T.interpolate(T + fd.Constant((1, 0)) * x * y)
+    mesh = fd.Mesh(T)
+
+    inner = fs.LaplaceInnerProduct(fixed_bids=[1])
+    Q = fs.FeControlSpace(mesh, inner)
+    mesh_m = Q.mesh_m
+    out = fd.File("domain.pvd")
+    q = fs.ControlVector(Q)
+    if pytestconfig.getoption("verbose"):
+        def cb(i): out.write(mesh_m.coordinates)
+    else:
+        def cb(i): pass
+
+    lower_bound = Q.T.copy(deepcopy=True)
+    lower_bound.interpolate(fd.Constant((-0.0, -0.0)))
+    upper_bound = Q.T.copy(deepcopy=True)
+    upper_bound.interpolate(fd.Constant((+1.3, +0.9)))
+
+    J = fsz.MoYoBoxConstraint(1, [2], Q, lower_bound=lower_bound,
+                              upper_bound=upper_bound,
+                              cb=lambda: out.write(mesh_m.coordinates),
+                              quadrature_degree=100)
+    g = q.clone()
+    J.gradient(g, q, None)
+    taylor_result = J.checkGradient(q, g, 9, 1)
+
+    for i in range(len(taylor_result)-1):
+        if taylor_result[i][3] > 1e-7:
+            assert taylor_result[i+1][3] <= taylor_result[i][3] * 0.11
+
+    params_dict = {
+        'General': {
+            'Secant': {'Type': 'Limited-Memory BFGS',
+                       'Maximum Storage': 2}},
+        'Step': {
+            'Type': 'Line Search',
+            'Line Search': {'Descent Method': {
+                'Type': 'Quasi-Newton Step'}}},
+        'Status Test': {
+            'Gradient Tolerance': 1e-10,
+            'Step Tolerance': 1e-10,
+            'Iteration Limit': 150}}
+
+    params = ROL.ParameterList(params_dict, "Parameters")
+    problem = ROL.OptimizationProblem(J, q)
+    solver = ROL.OptimizationSolver(problem, params)
+    solver.solve()
+    Tvec = Q.T.vector()
+    nodes = fd.DirichletBC(Q.V_r, fd.Constant((0.0, 0.0)), [2]).nodes
+    assert np.all(Tvec[nodes, 0] <= 1.3 + 1e-4)
+    assert np.all(Tvec[nodes, 1] <= 0.9 + 1e-4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_box_constraints.py
+++ b/tests/test_box_constraints.py
@@ -67,5 +67,72 @@ def test_box_constraint(pytestconfig):
     assert np.all(Tvec[nodes, 1] <= 0.9 + 1e-4)
 
 
+def test_objective_plus_box_constraint(pytestconfig):
+
+    n = 10
+    mesh = fd.UnitSquareMesh(n, n)
+    T = mesh.coordinates.copy(deepcopy=True)
+    (x, y) = fd.SpatialCoordinate(mesh)
+    T.interpolate(T + fd.Constant((0, 0)))
+    mesh = fd.Mesh(T)
+
+    inner = fs.LaplaceInnerProduct()
+    Q = fs.FeControlSpace(mesh, inner)
+    mesh_m = Q.mesh_m
+    q = fs.ControlVector(Q)
+    if pytestconfig.getoption("verbose"):
+        out = fd.File("domain.pvd")
+
+        def cb(): out.write(mesh_m.coordinates)
+    else:
+        def cb(): pass
+
+    lower_bound = Q.T.copy(deepcopy=True)
+    lower_bound.interpolate(fd.Constant((-0.2, -0.2)))
+    upper_bound = Q.T.copy(deepcopy=True)
+    upper_bound.interpolate(fd.Constant((+1.2, +1.2)))
+
+    J1 = fsz.MoYoBoxConstraint(10., [1, 2, 3, 4], Q, lower_bound=lower_bound,
+                               upper_bound=upper_bound,
+                               cb=cb,
+                               quadrature_degree=10)
+    # levelset test case
+    (x, y) = fd.SpatialCoordinate(Q.mesh_m)
+    f = (pow(x-0.5, 2))+pow(y-0.5, 2) - 4.
+    J2 = fsz.LevelsetFunctional(0.1 * f, Q, cb=cb, quadrature_degree=10)
+    J3 = fsz.MoYoSpectralConstraint(100, fd.Constant(0.6), Q, cb=cb, quadrature_degree=100)
+    # J = fs.ObjectiveSum(J2, J3)
+    J = fs.ObjectiveSum(fs.ObjectiveSum(J1, J2), J3)
+    g = q.clone()
+    J.gradient(g, q, None)
+    taylor_result = J.checkGradient(q, g, 9, 1)
+
+    # for i in range(len(taylor_result)-1):
+    #     if taylor_result[i][3] > 1e-6 and taylor_result[i][3] < 1e-3:
+    #         assert taylor_result[i+1][3] <= taylor_result[i][3] * 0.15
+
+    params_dict = {
+        'General': {
+            'Secant': {'Type': 'Limited-Memory BFGS',
+                       'Maximum Storage': 2}},
+        'Step': {
+            'Type': 'Line Search',
+            'Line Search': {'Descent Method': {
+                'Type': 'Quasi-Newton Step'}}},
+        'Status Test': {
+            'Gradient Tolerance': 1e-10,
+            'Step Tolerance': 1e-10,
+            'Iteration Limit': 10}}
+
+    params = ROL.ParameterList(params_dict, "Parameters")
+    problem = ROL.OptimizationProblem(J, q)
+    solver = ROL.OptimizationSolver(problem, params)
+    solver.solve()
+    Tvec = Q.T.vector()
+    nodes = fd.DirichletBC(Q.V_r, fd.Constant((0.0, 0.0)), [2]).nodes
+    assert np.all(Tvec[nodes, 0] <= 1.2 + 1e-1)
+    assert np.all(Tvec[nodes, 1] <= 1.2 + 1e-1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_spectral_constraint.py
+++ b/tests/test_spectral_constraint.py
@@ -31,11 +31,10 @@ def test_spectral_constraint(pytestconfig):
     J.update(q, None, -1)
     J.gradient(g, q, None)
     cb()
-    taylor_result = J.checkGradient(q, g, 9, 1)
+    taylor_result = J.checkGradient(q, g, 7, 1)
 
     for i in range(len(taylor_result)-1):
-        if taylor_result[i][3] > 1e-7:
-            assert taylor_result[i+1][3] <= taylor_result[i][3] * 0.11
+        assert taylor_result[i+1][3] <= taylor_result[i][3] * 0.11
 
     params_dict = {
         'General': {


### PR DESCRIPTION
I have added a few functionals that i have found useful in the past to regularise shape optimisation problems. 

- `MoYoBoxConstraint`: adds a box constraint on user specified parts of the boundary
- `MoYoSpectralConstraint` adds a constraint on the largest singular value of the gradient of the deformation field. This is useful to enforce high mesh quality
- `DeformationRegularization` adds a constraint of type J(f) =\|f|\ for different norms of f. Useful to avoid spurious movements in the volume.
-`CoarseDeformationRegularization`, same as above, but here the constraint is applied straight to the control and not its prolongation.

Furthermore, I added the ability to sum and scale functionals more easily: one can just write `J = J1 + 0.1 * J2` now. 

The first two constraints have `MoYo` in front of them to indicate that they will gain Augmented Lagrangian support at some point when I have the time.