### PR TITLE
pyadjoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,5 +12,6 @@ jobs:
       - run: . /home/firedrake/firedrake/bin/activate; pip3 install scipy
       - run: . /home/firedrake/firedrake/bin/activate; pip3 install roltrilinos
       - run: . /home/firedrake/firedrake/bin/activate; pip3 install ROL
-      - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; pytest
-            
+      - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make test
+      - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make examples
+      - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ jobs:
 
     steps:
       - checkout
-      - run: . /home/firedrake/firedrake/bin/activate; pip3 install wheel --upgrade
-      - run: . /home/firedrake/firedrake/bin/activate; pip3 install scipy
-      - run: . /home/firedrake/firedrake/bin/activate; pip3 install roltrilinos
-      - run: . /home/firedrake/firedrake/bin/activate; pip3 install ROL
       - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make test
       - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make examples
       - run: . /home/firedrake/firedrake/bin/activate; export PYTHONPATH=$(pwd):$PYTHONPATH; make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test, examples, lint
 
 test:
-	pytest test/
+	pytest
 
 examples:
 	cd examples/L2tracking/; python3 L2tracking_main.py; cd -

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test, examples, lint
+
+test:
+	pytest test/
+
+examples:
+	cd examples/L2tracking/; python3 L2tracking_main.py; cd -
+	cd examples/levelset/; python3 levelset.py; cd -
+
+lint:
+	echo "Not setup yet"
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-.PHONY: test, examples, lint
+.PHONY: test examples lint
 
 test:
 	pytest
 
 examples:
-	cd examples/L2tracking/; python3 L2tracking_main.py; cd -
-	cd examples/levelset/; python3 levelset.py; python3 levelset_boundary.py; python3 levelset_multigrid.py; python3 levelset_spline.py; cd -
+	cd examples/L2tracking/; python3 L2tracking_main.py
+	cd examples/levelset/; python3 levelset.py; python3 levelset_boundary.py; python3 levelset_multigrid.py; python3 levelset_spline.py
 
 lint:
 	echo "Not setup yet"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 
 examples:
 	cd examples/L2tracking/; python3 L2tracking_main.py; cd -
-	cd examples/levelset/; python3 levelset.py; cd -
+	cd examples/levelset/; python3 levelset.py; python3 levelset_boundary.py; python3 levelset_multigrid.py; python3 levelset_spline.py; cd -
 
 lint:
 	echo "Not setup yet"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,22 @@ The documentation is available [here](https://fireshape.readthedocs.io/en/latest
 ## Requirements
 
 Please install the [firedrake finite element library](https://www.firedrakeproject.org) first.
-You will need firedrake together with pyadjoint, i.e.
+You will need Firedrake together with pyadjoint, i.e.
 
+    curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
     python3 firedrake-install --install pyadjoint
 
 
 ## Installation
-Activate the firedrake virtualenv first and then run either:
+Activate the Firedrake virtualenv first
+
+    source path/to/firedrake/bin/activate
+
+Then install the _Rapid Optimization Library_
+
+    pip3 install --no-cache-dir roltrilinos rol
+
+Now you are ready to install fireshape.
 
 For users: 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The documentation is available [here](https://fireshape.readthedocs.io/en/latest
 ## Requirements
 
 Please install the [firedrake finite element library](https://www.firedrakeproject.org) first.
+You will need firedrake together with pyadjoint, i.e.
+
+    python3 firedrake-install --install pyadjoint
+
 
 ## Installation
 Activate the firedrake virtualenv first and then run either:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,3 +32,7 @@ WORKDIR /home/firedrake
 RUN echo "2019-04-25"
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
 RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --venv-name=firedrake --install pyadjoint --mpicc mpicc.mpich --mpicxx mpicxx.mpich --mpif90 mpif90.mpich --mpiexec mpiexec.mpich"
+RUN . /home/firedrake/firedrake/bin/activate; pip3 install wheel --upgrade
+RUN . /home/firedrake/firedrake/bin/activate; pip3 install scipy
+RUN . /home/firedrake/firedrake/bin/activate; pip3 install roltrilinos
+RUN . /home/firedrake/firedrake/bin/activate; pip3 install ROL

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,5 +29,6 @@ USER firedrake
 WORKDIR /home/firedrake
 
 # Now install firedrake
+RUN echo 2019-04-16
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
-RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --venv-name=firedrake"
+RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --venv-name=firedrake --install pyadjoint"

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -7,23 +7,19 @@ class PoissonSolver(PdeConstraint):
     """A Poisson BVP with hom DirBC as PDE constraint."""
     def __init__(self, mesh_m):
         super().__init__()
-        self.mesh_m = mesh_m
 
         # Setup problem
-        self.V = fd.FunctionSpace(self.mesh_m, "CG", 1)
-
-        # Preallocate solution variables for state and adjoint equations
-        self.solution = fda.Function(self.V, name="State")
+        V = fd.FunctionSpace(mesh_m, "CG", 1)
 
         # Weak form of Poisson problem
-        u = self.solution
-        v = fd.TestFunction(self.V)
-        self.f = fda.Constant(4.)
-        self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
-        self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
+        u = fda.Function(V, name="State")
+        v = fd.TestFunction(V)
+        f = fda.Constant(4.)
+        F = (fd.inner(fd.grad(u), fd.grad(v)) - f * v) * fd.dx
+        bcs = fda.DirichletBC(V, 0., "on_boundary")
 
         # PDE-solver parameters
-        self.params = {
+        params = {
             "ksp_type": "cg",
             "mat_type": "aij",
             "pc_type": "hypre",
@@ -33,10 +29,11 @@ class PoissonSolver(PdeConstraint):
             "ksp_stol": 1e-15,
         }
 
-        stateproblem = fda.NonlinearVariationalProblem(
-            self.F, self.solution, bcs=self.bcs)
+        self.solution = u
+        problem = fda.NonlinearVariationalProblem(
+            F, self.solution, bcs=bcs)
         self.solver = fda.NonlinearVariationalSolver(
-            stateproblem, solver_parameters=self.params)
+            problem, solver_parameters=params)
 
     def solve(self):
         super().solve()

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -2,6 +2,7 @@ import firedrake as fd
 import firedrake_adjoint as fda
 from fireshape import PdeConstraint
 
+
 class PoissonSolver(PdeConstraint):
     """A Poisson BVP with hom DirBC as PDE constraint."""
     def __init__(self, mesh_m):
@@ -14,31 +15,27 @@ class PoissonSolver(PdeConstraint):
         # Preallocate solution variables for state and adjoint equations
         self.solution = fda.Function(self.V, name="State")
         self.testfunction = fd.TestFunction(self.V)
-        self.solution_adj = fd.Function(self.V, name="Adjoint")
 
         # Weak form of Poisson problem
         u = self.solution
         v = self.testfunction
-        self.f = fd.Constant(4.)
         self.f = fda.Constant(4.)
         self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
-        self.bcs = fd.DirichletBC(self.V, 0., "on_boundary")
         self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
 
         # PDE-solver parameters
         self.nsp = None
         self.params = {
-                "ksp_type": "cg",
-                "mat_type": "aij",
-                "pc_type": "hypre",
-                "pc_factor_mat_solver_package": "boomerang",
-                "ksp_rtol": 1e-11,
-                "ksp_atol": 1e-11,
-                "ksp_stol": 1e-15,
-                      }
-
-        stateproblem = fd.NonlinearVariationalProblem(self.F, self.solution, bcs=self.bcs)
             "ksp_type": "cg",
+            "mat_type": "aij",
+            "pc_type": "hypre",
+            "pc_factor_mat_solver_package": "boomerang",
+            "ksp_rtol": 1e-11,
+            "ksp_atol": 1e-11,
+            "ksp_stol": 1e-15,
+        }
+
+        stateproblem = fda.NonlinearVariationalProblem(self.F, self.solution, bcs=self.bcs)
         self.solver = fda.NonlinearVariationalSolver(stateproblem, solver_parameters=self.params)
 
     def solve(self):

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -14,17 +14,15 @@ class PoissonSolver(PdeConstraint):
 
         # Preallocate solution variables for state and adjoint equations
         self.solution = fda.Function(self.V, name="State")
-        self.testfunction = fd.TestFunction(self.V)
 
         # Weak form of Poisson problem
         u = self.solution
-        v = self.testfunction
+        v = fd.TestFunction(self.V)
         self.f = fda.Constant(4.)
         self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
         self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
 
         # PDE-solver parameters
-        self.nsp = None
         self.params = {
             "ksp_type": "cg",
             "mat_type": "aij",
@@ -35,8 +33,10 @@ class PoissonSolver(PdeConstraint):
             "ksp_stol": 1e-15,
         }
 
-        stateproblem = fda.NonlinearVariationalProblem(self.F, self.solution, bcs=self.bcs)
-        self.solver = fda.NonlinearVariationalSolver(stateproblem, solver_parameters=self.params)
+        stateproblem = fda.NonlinearVariationalProblem(
+            self.F, self.solution, bcs=self.bcs)
+        self.solver = fda.NonlinearVariationalSolver(
+            stateproblem, solver_parameters=self.params)
 
     def solve(self):
         super().solve()

--- a/examples/L2tracking/L2tracking_main.py
+++ b/examples/L2tracking/L2tracking_main.py
@@ -4,46 +4,45 @@ import ROL
 from L2tracking_PDEconstraint import PoissonSolver
 from L2tracking_objective import L2trackingObjective
 
-#setup problem
+# setup problem
 mesh = fd.UnitSquareMesh(100, 100)
 Q = fs.FeControlSpace(mesh)
 inner = fs.ElasticityInnerProduct(Q)
 q = fs.ControlVector(Q, inner)
 
-#setup PDE constraint
+# setup PDE constraint
 mesh_m = Q.mesh_m
 e = PoissonSolver(mesh_m)
 
-#save state variable evolution in file u.pvd
+# save state variable evolution in file u.pvd
 e.solve()
 out = fd.File("u.pvd")
-cb = lambda: out.write(e.solution)
-cb()
 
-#create PDEconstrained objective functional
-J_ = L2trackingObjective(e, Q, cb=cb)
+# create PDEconstrained objective functional
+J_ = L2trackingObjective(e, Q, cb=lambda: out.write(e.solution))
 J = fs.ReducedObjective(J_, e)
 
-#ROL parameters
+# ROL parameters
 params_dict = {
-    'General': {
-        'Secant': {'Type': 'Limited-Memory BFGS',
-                   'Maximum Storage': 10}},
     'Step': {
-        'Type': 'Augmented Lagrangian',
-        'Line Search': {'Descent Method': {
-            'Type': 'Quasi-Newton Step'}
+        'Type': 'Line Search',
+        'Line Search': {
+            'Descent Method': {
+                'Type': 'Quasi-Newton Step'
+            }
         },
-        'Augmented Lagrangian': {
-            'Subproblem Step Type': 'Line Search',
-            'Penalty Parameter Growth Factor': 2.,
-            'Print Intermediate Optimization History': True,
-            'Subproblem Iteration Limit': 20
-        }},
+    },
+    'General': {
+        'Secant': {
+            'Type': 'Limited-Memory BFGS',
+            'Maximum Storage': 10
+        }
+    },
     'Status Test': {
         'Gradient Tolerance': 1e-4,
         'Step Tolerance': 1e-5,
-        'Iteration Limit': 15}
+        'Iteration Limit': 15
+    }
 }
 params = ROL.ParameterList(params_dict, "Parameters")
 problem = ROL.OptimizationProblem(J, q)

--- a/examples/L2tracking/L2tracking_objective.py
+++ b/examples/L2tracking/L2tracking_objective.py
@@ -2,13 +2,15 @@ import firedrake as fd
 from fireshape import ShapeObjective
 from L2tracking_PDEconstraint import PoissonSolver
 
+
 class L2trackingObjective(ShapeObjective):
     """L2 tracking functional for Poisson problem."""
     def __init__(self, pde_solver: PoissonSolver, *args,  **kwargs):
         super().__init__(*args, **kwargs)
         self.pde_solver = pde_solver
 
-        #target function, exact soln is disc of radius 0.6 centered at (0.5,0.5)
+        # target function, exact soln is disc of radius 0.6 centered at
+        # (0.5,0.5)
         (x, y) = fd.SpatialCoordinate(pde_solver.mesh_m)
         self.u_target = 0.36 - (x-0.5)*(x-0.5) - (y-0.5)*(y-0.5)
 

--- a/examples/L2tracking/L2tracking_objective.py
+++ b/examples/L2tracking/L2tracking_objective.py
@@ -7,14 +7,14 @@ class L2trackingObjective(ShapeObjective):
     """L2 tracking functional for Poisson problem."""
     def __init__(self, pde_solver: PoissonSolver, *args,  **kwargs):
         super().__init__(*args, **kwargs)
-        self.pde_solver = pde_solver
+        self.u = pde_solver.solution
 
         # target function, exact soln is disc of radius 0.6 centered at
         # (0.5,0.5)
-        (x, y) = fd.SpatialCoordinate(pde_solver.mesh_m)
+        (x, y) = fd.SpatialCoordinate(self.Q.mesh_m)
         self.u_target = 0.36 - (x-0.5)*(x-0.5) - (y-0.5)*(y-0.5)
 
     def value_form(self):
         """Evaluate misfit functional."""
-        u = self.pde_solver.solution
+        u = self.u
         return (u - self.u_target)**2 * fd.dx

--- a/examples/stokes/stokes.py
+++ b/examples/stokes/stokes.py
@@ -41,22 +41,29 @@ emul = ROL.StdVector(3)
 
 params_dict = {
     'General': {
-        'Secant': {'Type': 'Limited-Memory BFGS', 'Maximum Storage': 5}},
+        'Secant': {
+            'Type': 'Limited-Memory BFGS', 'Maximum Storage': 5
+        }
+    },
     'Step': {
         'Type': 'Augmented Lagrangian',
-        'Line Search': {'Descent Method': {
-            'Type': 'Quasi-Newton Step'}
+        'Line Search': {
+            'Descent Method': {
+                'Type': 'Quasi-Newton Step'
+            }
         },
         'Augmented Lagrangian': {
             'Subproblem Step Type': 'Line Search',
             'Penalty Parameter Growth Factor': 2.,
             'Print Intermediate Optimization History': True,
             'Subproblem Iteration Limit': 20
-        }},
+        }
+    },
     'Status Test': {
         'Gradient Tolerance': 1e-4,
         'Step Tolerance': 1e-5,
-        'Iteration Limit': 4}
+        'Iteration Limit': 4
+    }
 }
 params = ROL.ParameterList(params_dict, "Parameters")
 problem = ROL.OptimizationProblem(J, q, econ=econ, emul=emul)

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -555,7 +555,7 @@ class ControlVector(ROL.Vector):
 
         The name of this method is misleading, but it is dictated by ROL.
         """
-        res = ControlVector(self.controlspace, self.inner_product, \
+        res = ControlVector(self.controlspace, self.inner_product,
                             boundary_extension=self.boundary_extension)
         # res.set(self)
         return res

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -2,6 +2,7 @@ from .innerproduct import InnerProduct
 from .boundary_extension import ElasticityExtension
 import ROL
 import firedrake as fd
+import firedrake_adjoint as fda
 
 __all__ = ["FeControlSpace", "FeMultiGridControlSpace",
            "BsplineControlSpace", "ControlVector"]
@@ -103,9 +104,9 @@ class FeControlSpace(ControlSpace):
         # Create self.id and self.T, self.mesh_m, and self.V_m.
         X = fd.SpatialCoordinate(self.mesh_r)
         self.id = fd.interpolate(X, self.V_r)
-        self.T = fd.Function(self.V_r, name="T")
+        self.T = fda.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fd.Mesh(self.T)
+        self.mesh_m = fda.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
     def restrict(self, residual, out):
@@ -167,7 +168,7 @@ class FeMultiGridControlSpace(ControlSpace):
         self.id = fd.Function(self.V_r).interpolate(X)
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fd.Mesh(self.T)
+        self.mesh_m = fda.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
     def restrict(self, residual, out):
@@ -272,7 +273,7 @@ class BsplineControlSpace(ControlSpace):
         self.id = fd.Function(self.V_r).interpolate(X)
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fd.Mesh(self.T)
+        self.mesh_m = fda.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
         assert self.dim == self.mesh_r.geometric_dimension()

--- a/fireshape/innerproduct.py
+++ b/fireshape/innerproduct.py
@@ -46,8 +46,8 @@ class UflInnerProduct(InnerProduct):
         I: type PETSc.Mat, interpolation matrix between V and  ControlSpace
         """
         (V, I_interp) = Q.get_space_for_inner()
-        self.free_bids = list(
-                           V.mesh().topology.exterior_facets.unique_markers)
+        free_bids = list(V.mesh().topology.exterior_facets.unique_markers)
+        self.free_bids = [int(i) for i in free_bids]  # np.int->int
         for bid in self.fixed_bids:
             self.free_bids.remove(bid)
 

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -203,6 +203,9 @@ class ReducedObjective(ShapeObjective):
         """Update domain and solution to state and adjoint equation."""
         if self.Q.update_domain(x):
             try:
+                # We use pyadjoint to calculate adjoint and shape derivatives,
+                # in order to do this we need to "record a tape of the forward
+                # solve", pyadjoint will then figure out all necesary adjoints.
                 tape = fda.get_working_tape()
                 tape.clear_tape()
                 fda.continue_annotation()

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -175,6 +175,8 @@ class ReducedObjective(ShapeObjective):
         super().__init__(J.Q, J.cb)
         self.J = J
         self.e = e
+        # stop any annotation that might be ongoing as we only want to record
+        # what's happening in e.solve()
         fda.pause_annotation()
 
     def value(self, x, tol):

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -260,15 +260,9 @@ class ScaledObjective(Objective):
     def value(self, *args):
         return self.alpha * self.J.value(*args)
 
-    # def value_form(self):
-    #     return self.alpha * self.J.value_form()
-
     def derivative(self, out):
         self.J.derivative(out)
         out.scale(self.alpha)
-
-    # def derivative_form(self, v):
-    #     return self.alpha * self.derivative_form(v)
 
     def update(self, *args):
         self.J.update(*args)

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -22,7 +22,7 @@ class Objective(ROL.Objective):
         self.Q = Q  # ControlSpace
         self.V_r = Q.V_r  # fd.VectorFunctionSpace on reference mesh
         self.V_m = Q.V_m  # clone of V_r of physical mesh
-        self.mesh_m = self.V_m.mesh() #physical mesh
+        self.mesh_m = self.V_m.mesh()  # physical mesh
         self.cb = cb
         self.scale = scale
         self.deriv_r = fd.Function(self.V_r)

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -192,14 +192,14 @@ class ReducedObjective(ShapeObjective):
 
     def update(self, x, flag, iteration):
         """Update domain and solution to state and adjoint equation."""
-        self.Q.update_domain(x)
-        try:
-            self.e.solve()
-            self.e.solve_adjoint(self.J.scale * self.J.value_form())
-        except fd.ConvergenceError:
-            if self.cb is not None:
-                self.cb()
-            raise
+        if self.Q.update_domain(x):
+            try:
+                self.e.solve()
+                self.e.solve_adjoint(self.J.scale * self.J.value_form())
+            except fd.ConvergenceError:
+                if self.cb is not None:
+                    self.cb()
+                raise
         if iteration >= 0 and self.cb is not None:
             self.cb()
 

--- a/fireshape/pde_constraint.py
+++ b/fireshape/pde_constraint.py
@@ -4,49 +4,12 @@ import firedrake as fd
 class PdeConstraint(object):
     """
     Base class for PdeConstrain.
-
-    An instance of this class need to declare the following variables:
-        mesh_m: the physical mesh.
-        F: UFL form the represent state equation as zero search.
-        V: trial and test space of state equation.
-        bcs: boundary conditions of state/adjoint equation.
-        nsp: null-space of the state operator.
-        params: parameters used by fd.solve to solve F(x) = 0.
-        solution: container for solution to state equation.
-        testfunction: the testfunction used in the weak formulation.
-        solution_adj: containter for solution to adjoint equation.
     """
 
     def __init__(self):
         """Set counters of state/adjoint solves to 0."""
         self.num_solves = 0
-        self.num_adjoint_solves = 0
 
     def solve(self):
         """Abstract method that solves state equation."""
         self.num_solves += 1
-        self.stateproblem.solve()
-        return self.solution
-
-    def solve_adjoint(self, J):
-        """Abstract method that solves adjoint (and state) equation."""
-        self.num_solves += 1
-        self.num_adjoint_solves += 1
-        # Check if F is linear i.e. using TrialFunction
-        if len(self.F.arguments()) != 2:
-            bil_form = fd.derivative(self.F, self.solution,
-                                     fd.TrialFunction(self.V))
-        else:
-            bil_form = fd.lhs(self.F)
-        a = fd.adjoint(bil_form)
-        rhs = -fd.derivative(J, self.solution, fd.TestFunction(self.V))
-        fd.solve(a == rhs, self.solution_adj, bcs=fd.homogenize(self.bcs),
-                 nullspace=self.nsp, transpose_nullspace=self.nsp,
-                 solver_parameters=self.params)
-        return self.solution_adj
-
-    def derivative_form(self, v):
-        """Shape directional derivative of self.F."""
-        X = fd.SpatialCoordinate(self.mesh_m)
-        L = fd.replace(self.F, {self.testfunction: self.solution_adj})
-        return fd.derivative(L, X, v)

--- a/fireshape/zoo/fluid_solvers.py
+++ b/fireshape/zoo/fluid_solvers.py
@@ -1,4 +1,5 @@
 import firedrake as fd
+import firedrake_adjoint as fda
 from ..pde_constraint import PdeConstraint
 
 __all__ = ["StokesSolver"]
@@ -28,7 +29,7 @@ class FluidSolver(PdeConstraint):
         self.inflow_bids = inflow_bids
         self.inflow_expr = inflow_expr
         self.noslip_bids = noslip_bids
-        self.nu = fd.Constant(nu)
+        self.nu = fda.Constant(nu)
 
         # Setup problem
         self.V = self.get_functionspace()
@@ -41,13 +42,20 @@ class FluidSolver(PdeConstraint):
         self.outflow_bids = all_bids
 
         # Preallocate solution variables for state and adjoint equations
-        self.solution = fd.Function(self.V, name="State")
-        self.solution_adj = fd.Function(self.V, name="Adjoint")
+        self.solution = fda.Function(self.V, name="State")
 
         self.F = self.get_weak_form()
         self.bcs = self.get_boundary_conditions()
         self.nsp = self.get_nullspace()
         self.params = self.get_parameters()
+        problem = fda.NonlinearVariationalProblem(self.F, self.solution,
+                                                  bcs=self.bcs,)
+        self.solver = fda.NonlinearVariationalSolver(
+            problem, solver_parameters=self.params, nullspace=self.nsp)
+
+    def solve(self):
+        super().solve()
+        self.solver.solve()
 
     def get_functionspace(self):
         """Construct trial/test space for state and adjoint equations."""
@@ -72,11 +80,11 @@ class FluidSolver(PdeConstraint):
 
         bcs = []
         if len(self.inflow_bids) is not None:
-            bcs.append(fd.DirichletBC(self.V.sub(0), self.inflow_expr,
-                                   self.inflow_bids))
-        if len(self.noslip_bids)>0:
-            bcs.append(fd.DirichletBC(self.V.sub(0), zerovector,
-                                   self.noslip_bids))
+            bcs.append(fda.DirichletBC(self.V.sub(0), self.inflow_expr,
+                                       self.inflow_bids))
+        if len(self.noslip_bids) > 0:
+            bcs.append(fda.DirichletBC(self.V.sub(0), zerovector,
+                                       self.noslip_bids))
         return bcs
 
     def get_nullspace(self):
@@ -96,21 +104,14 @@ class StokesSolver(FluidSolver):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def solve(self):
-        super().solve()
-        fd.solve(fd.lhs(self.F) == fd.rhs(self.F), self.solution, bcs=self.bcs,
-              nullspace=self.nsp, transpose_nullspace=self.nsp,
-              solver_parameters=self.params)
-        return self.solution
-
     def get_weak_form(self):
         (v, q) = fd.TestFunctions(self.V)
-        (u, p) = fd.TrialFunctions(self.V)
+        (u, p) = fd.split(self.solution)
         F = (
             self.nu * fd.inner(fd.grad(u), fd.grad(v)) * fd.dx
             - p * fd.div(v) * fd.dx
             + fd.div(u) * q * fd.dx
-            + fd.inner(fd.Constant((0., 0.)), v) * fd.dx
+            + fd.inner(fda.Constant((0., 0.)), v) * fd.dx
         )
         return F
 
@@ -129,24 +130,3 @@ class StokesSolver(FluidSolver):
             raise NotImplementedError("Iterative solver has not been "
                                       "implemented.")
         return ksp_params
-
-    def derivative_form(self, deformation):
-        """Shape directional derivative of self.F wrt to w."""
-        w = deformation
-        u = self.solution.split()[0]
-        p = self.solution.split()[1]
-        v = self.solution_adj.split()[0]
-        q = self.solution_adj.split()[1]
-        nu = self.nu
-
-        deriv = -fd.inner(nu * fd.grad(u) * fd.grad(w),
-                       fd.grad(v)) * fd.dx
-        deriv -= fd.inner(nu * fd.grad(u),
-                       fd.grad(v) * fd.grad(w)) * fd.dx
-        deriv += fd.tr(fd.grad(v)*fd.grad(w)) * p * fd.dx
-        deriv -= fd.tr(fd.grad(u)*fd.grad(w)) * q * fd.dx
-
-        deriv += fd.div(w) * fd.inner(nu * fd.grad(u), fd.grad(v)) * fd.dx
-        deriv -= fd.div(w) * fd.inner(fd.div(v), p) * fd.dx
-        deriv += fd.div(w) * fd.inner(fd.div(u), q) * fd.dx
-        return deriv

--- a/fireshape/zoo/fluid_solvers.py
+++ b/fireshape/zoo/fluid_solvers.py
@@ -4,6 +4,7 @@ from ..pde_constraint import PdeConstraint
 
 __all__ = ["StokesSolver"]
 
+
 class FluidSolver(PdeConstraint):
     """Abstract class for fluid problems as PdeContraint."""
     def __init__(self, mesh_m, mini=False, direct=True,
@@ -65,7 +66,7 @@ class FluidSolver(PdeConstraint):
                 + fd.FiniteElement("B", fd.triangle, 3)
             Vvel = fd.VectorFunctionSpace(self.mesh_m, mini)
         else:
-            #P2/P1 Taylor-Hood elements
+            # P2/P1 Taylor-Hood elements
             Vvel = fd.VectorFunctionSpace(self.mesh_m, "Lagrange", 2)
         Vpres = fd.FunctionSpace(self.mesh_m, "CG", 1)
         return Vvel * Vpres
@@ -91,7 +92,7 @@ class FluidSolver(PdeConstraint):
         """Specify nullspace of state/adjoint equation."""
 
         if len(self.outflow_bids) > 0:
-            #If the pressure is fixed (anywhere) by a Dirichlet bc, nsp = None
+            # If the pressure is fixed (anywhere) by a Dirichlet bc, nsp = None
             nsp = None
         else:
             nsp = fd.MixedVectorSpaceBasis(

--- a/tests/test_L2tracking.py
+++ b/tests/test_L2tracking.py
@@ -18,17 +18,15 @@ class PoissonSolver(PdeConstraint):
 
         # Preallocate solution variables for state and adjoint equations
         self.solution = fda.Function(self.V, name="State")
-        self.testfunction = fd.TestFunction(self.V)
 
         # Weak form of Poisson problem
         u = self.solution
-        v = self.testfunction
+        v = fd.TestFunction(self.V)
         self.f = fda.Constant(4.)
         self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
         self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
 
         # PDE-solver parameters
-        self.nsp = None
         self.params = {
             "ksp_type": "cg",
             "mat_type": "aij",
@@ -97,23 +95,24 @@ def run_L2tracking_optimization(write_output=False):
     # ROL parameters
     params_dict = {
         'General': {
-            'Secant': {'Type': 'Limited-Memory BFGS',
-                       'Maximum Storage': 10}},
+            'Secant': {
+                'Type': 'Limited-Memory BFGS',
+                'Maximum Storage': 10
+            }
+        },
         'Step': {
-            'Type': 'Augmented Lagrangian',
-            'Line Search': {'Descent Method': {
-                'Type': 'Quasi-Newton Step'}
+            'Type': 'Line Search',
+            'Line Search': {
+                'Descent Method': {
+                    'Type': 'Quasi-Newton Step'
+                }
             },
-            'Augmented Lagrangian': {
-                'Subproblem Step Type': 'Line Search',
-                'Penalty Parameter Growth Factor': 2.,
-                #'Print Intermediate Optimization History': False,
-                'Subproblem Iteration Limit': 20
-            }},
+        },
         'Status Test': {
             'Gradient Tolerance': 1e-4,
             'Step Tolerance': 1e-5,
-            'Iteration Limit': 15}
+            'Iteration Limit': 15
+        }
     }
 
     # assemble and solve ROL optimization problem

--- a/tests/test_L2tracking.py
+++ b/tests/test_L2tracking.py
@@ -1,9 +1,9 @@
 import pytest
 import firedrake as fd
+import firedrake_adjoint as fda
 import fireshape as fs
 from fireshape import ShapeObjective
 from fireshape import PdeConstraint
-import fireshape.zoo as fsz
 import ROL
 
 
@@ -17,31 +17,37 @@ class PoissonSolver(PdeConstraint):
         self.V = fd.FunctionSpace(self.mesh_m, "CG", 1)
 
         # Preallocate solution variables for state and adjoint equations
-        self.solution = fd.Function(self.V, name="State")
+        self.solution = fda.Function(self.V, name="State")
         self.testfunction = fd.TestFunction(self.V)
-        self.solution_adj = fd.Function(self.V, name="Adjoint")
 
         # Weak form of Poisson problem
         u = self.solution
         v = self.testfunction
-        self.f = fd.Constant(4.)
+        self.f = fda.Constant(4.)
         self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
-        self.bcs = fd.DirichletBC(self.V, 0., "on_boundary")
+        self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
 
         # PDE-solver parameters
         self.nsp = None
-        self.params = { 
-                "ksp_type": "cg",
-                "mat_type": "aij",
-                "pc_type": "hypre",
-                "pc_factor_mat_solver_package": "boomerang",
-                "ksp_rtol": 1e-11,
-                "ksp_atol": 1e-11,
-                "ksp_stol": 1e-15,
-                      }   
+        self.params = {
+            "ksp_type": "cg",
+            "mat_type": "aij",
+            "pc_type": "hypre",
+            "pc_factor_mat_solver_package": "boomerang",
+            "ksp_rtol": 1e-11,
+            "ksp_atol": 1e-11,
+            "ksp_stol": 1e-15,
+        }
 
-        stateproblem = fd.NonlinearVariationalProblem(self.F, self.solution, bcs=self.bcs)
-        self.stateproblem = fd.NonlinearVariationalSolver(stateproblem, solver_parameters=self.params)
+        stateproblem = fda.NonlinearVariationalProblem(
+            self.F, self.solution, bcs=self.bcs)
+        self.solver = fda.NonlinearVariationalSolver(
+            stateproblem, solver_parameters=self.params)
+
+    def solve(self):
+        super().solve()
+        self.solver.solve()
+
 
 class L2trackingObjective(ShapeObjective):
     """L2 tracking functional for Poisson problem."""
@@ -49,7 +55,8 @@ class L2trackingObjective(ShapeObjective):
         super().__init__(*args, **kwargs)
         self.pde_solver = pde_solver
 
-        #target function, exact soln is disc of radius 0.6 centered at (0.5,0.5)
+        # target function, exact soln is disc of radius 0.6 centered at
+        # (0.5,0.5)
         (x, y) = fd.SpatialCoordinate(pde_solver.mesh_m)
         self.u_target = 0.36 - (x-0.5)*(x-0.5) - (y-0.5)*(y-0.5)
 
@@ -62,7 +69,7 @@ class L2trackingObjective(ShapeObjective):
 def run_L2tracking_optimization(write_output=False):
     """ Test template for fsz.LevelsetFunctional."""
 
-    #tool for developing new tests, allows storing shape iterates
+    # tool for developing new tests, allows storing shape iterates
     if write_output:
         out = fd.File("domain.pvd")
 
@@ -73,22 +80,22 @@ def run_L2tracking_optimization(write_output=False):
     else:
         cb = None
 
-    #setup problem
+    # setup problem
     mesh = fd.UnitSquareMesh(30, 30)
     Q = fs.FeControlSpace(mesh)
     inner = fs.ElasticityInnerProduct(Q)
     q = fs.ControlVector(Q, inner)
 
-    #setup PDE constraint
+    # setup PDE constraint
     mesh_m = Q.mesh_m
     e = PoissonSolver(mesh_m)
 
-    #create PDEconstrained objective functional
+    # create PDEconstrained objective functional
     J_ = L2trackingObjective(e, Q, cb=cb)
     J = fs.ReducedObjective(J_, e)
 
-    #ROL parameters
-    params_dict = { 
+    # ROL parameters
+    params_dict = {
         'General': {
             'Secant': {'Type': 'Limited-Memory BFGS',
                        'Maximum Storage': 10}},
@@ -96,10 +103,10 @@ def run_L2tracking_optimization(write_output=False):
             'Type': 'Augmented Lagrangian',
             'Line Search': {'Descent Method': {
                 'Type': 'Quasi-Newton Step'}
-            },  
+            },
             'Augmented Lagrangian': {
                 'Subproblem Step Type': 'Line Search',
-                'Penalty Parameter Growth Factor': 2., 
+                'Penalty Parameter Growth Factor': 2.,
                 #'Print Intermediate Optimization History': False,
                 'Subproblem Iteration Limit': 20
             }},
@@ -119,9 +126,11 @@ def run_L2tracking_optimization(write_output=False):
     state = solver.getAlgorithmState()
     assert (state.gnorm < 1e-4)
 
+
 def test_L2tracking(pytestconfig):
-    verbose=False
+    verbose = False
     run_L2tracking_optimization(write_output=verbose)
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_levelset.py
+++ b/tests/test_levelset.py
@@ -5,10 +5,16 @@ import fireshape.zoo as fsz
 import ROL
 
 
-@pytest.mark.parametrize("dim", [2, 3])
-@pytest.mark.parametrize("inner_t", [fs.H1InnerProduct, fs.ElasticityInnerProduct, fs.LaplaceInnerProduct])
-@pytest.mark.parametrize("controlspace_t", [fs.FeControlSpace, fs.FeMultiGridControlSpace, fs.BsplineControlSpace])
-@pytest.mark.parametrize("use_extension", ["wo_ext", "w_ext", "w_ext_fixed_fim"])
+@pytest.mark.parametrize("dim",
+                         [2, 3])
+@pytest.mark.parametrize("inner_t", [fs.H1InnerProduct,
+                                     fs.ElasticityInnerProduct,
+                                     fs.LaplaceInnerProduct])
+@pytest.mark.parametrize("controlspace_t", [fs.FeControlSpace,
+                                            fs.FeMultiGridControlSpace,
+                                            fs.BsplineControlSpace])
+@pytest.mark.parametrize("use_extension", ["wo_ext", "w_ext",
+                                           "w_ext_fixed_fim"])
 def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
     verbose = pytestconfig.getoption("verbose")
     """ Test template for fsz.LevelsetFunctional."""
@@ -31,11 +37,11 @@ def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
         if dim == 2:
             bbox = [(-2, 2), (-2, 2)]
             orders = [2, 2]
-            levels =  [4, 4]
+            levels = [4, 4]
         else:
-            bbox = [(-3, 3), (-3, 3), (-3,3)]
+            bbox = [(-3, 3), (-3, 3), (-3, 3)]
             orders = [2, 2, 2]
-            levels =  [3, 3, 3]
+            levels = [3, 3, 3]
         Q = fs.BsplineControlSpace(mesh, bbox, orders, levels)
     elif controlspace_t == fs.FeMultiGridControlSpace:
         Q = fs.FeMultiGridControlSpace(mesh, refinements=1, order=2)
@@ -93,20 +99,29 @@ def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
     q.scale(0)
     """ End taylor test """
 
-    grad_tol = 1e-6 if dim==2 else 1e-4
+    grad_tol = 1e-6 if dim == 2 else 1e-4
     # ROL parameters
     params_dict = {
         'General': {
-            'Secant': {'Type': 'Limited-Memory BFGS',
-                       'Maximum Storage': 50}},
+            'Secant': {
+                'Type': 'Limited-Memory BFGS',
+                'Maximum Storage': 50
+            }
+        },
         'Step': {
             'Type': 'Line Search',
-            'Line Search': {'Descent Method': {
-                'Type': 'Quasi-Newton Step'}}},
+            'Line Search': {
+                'Descent Method': {
+                    'Type': 'Quasi-Newton Step'
+                }
+            }
+        },
         'Status Test': {
             'Gradient Tolerance': grad_tol,
             'Step Tolerance': 1e-10,
-            'Iteration Limit': 150}}
+            'Iteration Limit': 150
+        }
+    }
 
     # assemble and solve ROL optimization problem
     params = ROL.ParameterList(params_dict, "Parameters")
@@ -117,6 +132,7 @@ def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
     # verify that the norm of the gradient at optimum is small enough
     state = solver.getAlgorithmState()
     assert (state.gnorm < grad_tol)
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_spectral_constraint.py
+++ b/tests/test_spectral_constraint.py
@@ -10,8 +10,8 @@ import ROL
 def test_spectral_constraint(pytestconfig):
     n = 5
     mesh = fd.UnitSquareMesh(n, n)
-    T = mesh.coordinates.copy(deepcopy=True)
-    T.interpolate(T - fd.Constant((0.5, 0.5)))
+    T = fd.Function(fd.VectorFunctionSpace(mesh, "CG", 1)).interpolate(
+        fd.SpatialCoordinate(mesh)-fd.Constant((0.5, 0.5)))
     mesh = fd.Mesh(T)
     Q = fs.FeControlSpace(mesh)
     inner = fs.LaplaceInnerProduct(Q)


### PR DESCRIPTION
- We now use pyadjoint to calculate adjoints and shape derivatives when there are pde constraints
This enabled a couple of simplications across the code, so I went through examples and some tests and cut out some unneeded bits

- Changed `update_domain(self, q)` in `control.py` to check whether the domain has actually changed 

- changed circleci to run the levelset and the l2tracking example. should at some point probably run all examples, or at least the quick ones