### PR TITLE
pyadjointintegration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:18.04
 
 # This DockerFile is looked after by
-MAINTAINER Florian Wechsung <wechsung@maths.ox.ac.uk>
+MAINTAINER Florian Wechsung <wechsung@nyu.edu>
 
 # Update and install required packages for Firedrake
 USER root
@@ -15,7 +15,8 @@ RUN apt-get update \
                  cmake gfortran git libblas-dev liblapack-dev \
                  libmpich-dev libtool mercurial mpich\
                  python3-dev python3-pip python3-tk python3-venv \
-                 zlib1g-dev libboost-dev gmsh patchelf \
+                 python3-requests zlib1g-dev libboost-dev sudo bison flex \
+                 gmsh patchelf docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -29,9 +30,9 @@ USER firedrake
 WORKDIR /home/firedrake
 
 # Now install firedrake
-RUN echo "2019-04-25"
+RUN echo "2020-02-20"
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install
-RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --venv-name=firedrake --install pyadjoint --mpicc mpicc.mpich --mpicxx mpicxx.mpich --mpif90 mpif90.mpich --mpiexec mpiexec.mpich"
+RUN bash -c "python3 firedrake-install --no-package-manager --disable-ssh --mpicc mpicc.mpich --mpicxx mpicxx.mpich --mpif90 mpif90.mpich --mpiexec mpiexec.mpich"
 RUN . /home/firedrake/firedrake/bin/activate; pip3 install wheel --upgrade
 RUN . /home/firedrake/firedrake/bin/activate; pip3 install scipy
 RUN . /home/firedrake/firedrake/bin/activate; pip3 install roltrilinos

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -18,7 +18,7 @@ class PoissonSolver(PdeConstraint):
         self.bcs = fd.DirichletBC(V, 0., "on_boundary")
 
         # PDE-solver parameters
-        params = {
+        self.params = {
             "ksp_type": "cg",
             "mat_type": "aij",
             "pc_type": "hypre",
@@ -33,7 +33,7 @@ class PoissonSolver(PdeConstraint):
         # problem = fd.NonlinearVariationalProblem(
         #     self.F, self.solution, bcs=self.bcs)
         # self.solver = fd.NonlinearVariationalSolver(
-        #     problem, solver_parameters=params)
+        #     problem, solver_parameters=self.params)
 
     def solve(self):
         super().solve()

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -37,5 +37,6 @@ class PoissonSolver(PdeConstraint):
 
     def solve(self):
         super().solve()
-        fd.solve(self.F==0, self.solution, bcs=self.bcs, solver_parameters=self.params)
+        fd.solve(self.F == 0, self.solution, bcs=self.bcs,
+                 solver_parameters=self.params)
         # self.solver.solve()

--- a/examples/L2tracking/L2tracking_PDEconstraint.py
+++ b/examples/L2tracking/L2tracking_PDEconstraint.py
@@ -1,5 +1,4 @@
 import firedrake as fd
-import firedrake_adjoint as fda
 from fireshape import PdeConstraint
 
 
@@ -12,11 +11,11 @@ class PoissonSolver(PdeConstraint):
         V = fd.FunctionSpace(mesh_m, "CG", 1)
 
         # Weak form of Poisson problem
-        u = fda.Function(V, name="State")
+        u = fd.Function(V, name="State")
         v = fd.TestFunction(V)
-        f = fda.Constant(4.)
-        F = (fd.inner(fd.grad(u), fd.grad(v)) - f * v) * fd.dx
-        bcs = fda.DirichletBC(V, 0., "on_boundary")
+        f = fd.Constant(4.)
+        self.F = (fd.inner(fd.grad(u), fd.grad(v)) - f * v) * fd.dx
+        self.bcs = fd.DirichletBC(V, 0., "on_boundary")
 
         # PDE-solver parameters
         params = {
@@ -30,11 +29,13 @@ class PoissonSolver(PdeConstraint):
         }
 
         self.solution = u
-        problem = fda.NonlinearVariationalProblem(
-            F, self.solution, bcs=bcs)
-        self.solver = fda.NonlinearVariationalSolver(
-            problem, solver_parameters=params)
+
+        # problem = fd.NonlinearVariationalProblem(
+        #     self.F, self.solution, bcs=self.bcs)
+        # self.solver = fd.NonlinearVariationalSolver(
+        #     problem, solver_parameters=params)
 
     def solve(self):
         super().solve()
-        self.solver.solve()
+        fd.solve(self.F==0, self.solution, bcs=self.bcs, solver_parameters=self.params)
+        # self.solver.solve()

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -1,7 +1,6 @@
 from .innerproduct import InnerProduct
 import ROL
 import firedrake as fd
-import firedrake_adjoint as fda
 
 __all__ = ["FeControlSpace", "FeMultiGridControlSpace",
            "BsplineControlSpace", "ControlVector"]
@@ -135,9 +134,9 @@ class FeControlSpace(ControlSpace):
         # Create self.id and self.T, self.mesh_m, and self.V_m.
         X = fd.SpatialCoordinate(self.mesh_r)
         self.id = fd.interpolate(X, self.V_r)
-        self.T = fda.Function(self.V_r, name="T")
+        self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fda.Mesh(self.T)
+        self.mesh_m = fd.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
     def restrict(self, residual, out):
@@ -219,7 +218,7 @@ class FeMultiGridControlSpace(ControlSpace):
         self.id = fd.Function(self.V_r).interpolate(X)
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fda.Mesh(self.T)
+        self.mesh_m = fd.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
     def restrict(self, residual, out):
@@ -347,7 +346,7 @@ class BsplineControlSpace(ControlSpace):
         self.id = fd.Function(self.V_r).interpolate(X)
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
-        self.mesh_m = fda.Mesh(self.T)
+        self.mesh_m = fd.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
 
         assert self.dim == self.mesh_r.geometric_dimension()

--- a/fireshape/innerproduct.py
+++ b/fireshape/innerproduct.py
@@ -283,7 +283,6 @@ class SurfaceInnerProduct(InnerProduct):
         # petsc doesn't like matrices with zero rows
         a += 1e-10 * fd.inner(u, v) * fd.dx
         A = fd.assemble(a, mat_type="aij")
-        A.force_evaluation()
         A = A.petscmat
         tdim = V.mesh().topological_dimension()
 

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -1,6 +1,5 @@
 import ROL
 import firedrake as fd
-import firedrake_adjoint as fda
 from .control import ControlSpace
 from .pde_constraint import PdeConstraint
 
@@ -177,6 +176,7 @@ class ReducedObjective(ShapeObjective):
         self.e = e
         # stop any annotation that might be ongoing as we only want to record
         # what's happening in e.solve()
+        import firedrake_adjoint as fda
         fda.pause_annotation()
 
     def value(self, x, tol):
@@ -209,16 +209,17 @@ class ReducedObjective(ShapeObjective):
                 # in order to do this we need to "record a tape of the forward
                 # solve", pyadjoint will then figure out all necessary
                 # adjoints.
+                import firedrake_adjoint as fda
                 tape = fda.get_working_tape()
                 tape.clear_tape()
                 fda.continue_annotation()
                 mesh_m = self.J.Q.mesh_m
-                s = fda.Function(self.J.V_m)
+                s = fd.Function(self.J.V_m)
                 mesh_m.coordinates.assign(mesh_m.coordinates + s)
                 self.s = s
                 self.c = fda.Control(s)
                 self.e.solve()
-                Jpyadj = fda.assemble(self.J.value_form())
+                Jpyadj = fd.assemble(self.J.value_form())
                 self.Jred = fda.ReducedFunctional(Jpyadj, self.c)
                 fda.pause_annotation()
             except fd.ConvergenceError:

--- a/fireshape/zoo/fluid_solvers.py
+++ b/fireshape/zoo/fluid_solvers.py
@@ -57,7 +57,8 @@ class FluidSolver(PdeConstraint):
     def solve(self):
         super().solve()
         # self.solver.solve()
-        fd.solve(self.F == 0, self.solution, bcs=self.bcs, solver_parameters=self.params, nullspace=self.nsp)
+        fd.solve(self.F == 0, self.solution, bcs=self.bcs,
+                 solver_parameters=self.params, nullspace=self.nsp)
 
     def get_functionspace(self):
         """Construct trial/test space for state and adjoint equations."""
@@ -83,10 +84,10 @@ class FluidSolver(PdeConstraint):
         bcs = []
         if len(self.inflow_bids) is not None:
             bcs.append(fd.DirichletBC(self.V.sub(0), self.inflow_expr,
-                                       self.inflow_bids))
+                                      self.inflow_bids))
         if len(self.noslip_bids) > 0:
             bcs.append(fd.DirichletBC(self.V.sub(0), zerovector,
-                                       self.noslip_bids))
+                                      self.noslip_bids))
         return bcs
 
     def get_nullspace(self):

--- a/tests/test_L2tracking.py
+++ b/tests/test_L2tracking.py
@@ -1,6 +1,5 @@
 import pytest
 import firedrake as fd
-import firedrake_adjoint as fda
 import fireshape as fs
 from fireshape import ShapeObjective
 from fireshape import PdeConstraint
@@ -17,14 +16,14 @@ class PoissonSolver(PdeConstraint):
         self.V = fd.FunctionSpace(self.mesh_m, "CG", 1)
 
         # Preallocate solution variables for state and adjoint equations
-        self.solution = fda.Function(self.V, name="State")
+        self.solution = fd.Function(self.V, name="State")
 
         # Weak form of Poisson problem
         u = self.solution
         v = fd.TestFunction(self.V)
-        self.f = fda.Constant(4.)
+        self.f = fd.Constant(4.)
         self.F = (fd.inner(fd.grad(u), fd.grad(v)) - self.f * v) * fd.dx
-        self.bcs = fda.DirichletBC(self.V, 0., "on_boundary")
+        self.bcs = fd.DirichletBC(self.V, 0., "on_boundary")
 
         # PDE-solver parameters
         self.params = {
@@ -37,9 +36,9 @@ class PoissonSolver(PdeConstraint):
             "ksp_stol": 1e-15,
         }
 
-        stateproblem = fda.NonlinearVariationalProblem(
+        stateproblem = fd.NonlinearVariationalProblem(
             self.F, self.solution, bcs=self.bcs)
-        self.solver = fda.NonlinearVariationalSolver(
+        self.solver = fd.NonlinearVariationalSolver(
             stateproblem, solver_parameters=self.params)
 
     def solve(self):


### PR DESCRIPTION
The way firedrake and pyadjoint interact has been changed. This branch brings fireshape up to speed.

There is currently an issue in pyadjoint that solver_parameters are not passed correctly when using the `VariationalSolver` interface instead of `solve(...)` (see https://github.com/dolfin-adjoint/pyadjoint/issues/6), so I had to revert a couple of PDE constrained examples.