### PR TITLE
fixed interpolation space for inner product and added test

### DIFF
--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -340,8 +340,8 @@ class BsplineControlSpace(ControlSpace):
         self.comm = mesh.mpi_comm()
         # create temporary self.mesh_r and self.V_r to assemble innerproduct
         if self.dim == 2:
-            nx = len(self.knots[0]) - 1
-            ny = len(self.knots[1]) - 1
+            nx = 2**levels[0]
+            ny = 2**levels[1]
             Lx = self.bbox[0][1] - self.bbox[0][0]
             Ly = self.bbox[1][1] - self.bbox[1][0]
             meshloc = fd.RectangleMesh(nx, ny, Lx, Ly, quadrilateral=True,
@@ -353,9 +353,9 @@ class BsplineControlSpace(ControlSpace):
 
         elif self.dim == 3:
             # maybe use extruded meshes, quadrilateral not available
-            nx = len(self.knots[0]) - 1
-            ny = len(self.knots[1]) - 1
-            nz = len(self.knots[2]) - 1
+            nx = 2**levels[0]
+            ny = 2**levels[1]
+            nz = 2**levels[2]
             Lx = self.bbox[0][1] - self.bbox[0][0]
             Ly = self.bbox[1][1] - self.bbox[1][0]
             Lz = self.bbox[2][1] - self.bbox[2][0]
@@ -367,15 +367,18 @@ class BsplineControlSpace(ControlSpace):
             # inner_product.fixed_bids = [1,2,3,4,5,6]
 
         self.mesh_r = meshloc
-        maxdegree = max(self.orders) - 1
+        if self.dim == 2:
+            degree = max(self.orders) - 1
+        elif self.dim == 3:
+            degree = reduce(lambda x, y: x + y, self.orders) - 3
 
         # Bspline control space
-        self.V_control = fd.VectorFunctionSpace(self.mesh_r, "CG", maxdegree)
+        self.V_control = fd.VectorFunctionSpace(self.mesh_r, "CG", degree)
         self.I_control = self.build_interpolation_matrix(self.V_control)
 
         # standard construction of ControlSpace
         self.mesh_r = mesh
-        element = fd.VectorElement("CG", mesh.ufl_cell(), maxdegree)
+        element = fd.VectorElement("CG", mesh.ufl_cell(), degree)
         self.V_r = fd.FunctionSpace(self.mesh_r, element)
         X = fd.SpatialCoordinate(self.mesh_r)
         self.id = fd.Function(self.V_r).interpolate(X)

--- a/tests/test_bspline_control_space.py
+++ b/tests/test_bspline_control_space.py
@@ -1,0 +1,51 @@
+import pytest
+import firedrake as fd
+import fireshape as fs
+
+
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("inner_t", [fs.H1InnerProduct,
+                                     fs.ElasticityInnerProduct,
+                                     fs.LaplaceInnerProduct])
+@pytest.mark.parametrize("order", [2, 3])
+def test_bspline_control_space(dim, inner_t, order, pytestconfig):
+    """ Test template for fs.BsplineControlSpace."""
+
+    if dim == 2:
+        mesh = fs.DiskMesh(0.1)
+        bbox = [(-2, 2), (-2, 2)]
+        orders = [order] * 2
+        levels = [4, 4]
+    elif dim == 3:
+        mesh = fs.SphereMesh(0.2)
+        bbox = [(-3, 3), (-3, 3), (-3, 3)]
+        orders = [order] * 3
+        levels = [2, 2, 2]
+    else:
+        raise NotImplementedError
+
+    Q = fs.BsplineControlSpace(mesh, bbox, orders, levels)
+    A = inner_t(Q).A
+
+    V = Q.V_control
+    meshloc = V.mesh()
+    elem = V.ufl_element()
+    degree = elem.degree()
+    Q.mesh_r = meshloc
+
+    if degree > 1:
+        Q.V_control = fd.FunctionSpace(
+            meshloc, elem.reconstruct(degree=degree-1))
+        Q.I_control = Q.build_interpolation_matrix(Q.V_control)
+        A_lower_order = inner_t(Q).A
+        assert (A_lower_order - A).norm() > 1e-12
+
+    Q.V_control = fd.FunctionSpace(
+        meshloc, elem.reconstruct(degree=degree+1))
+    Q.I_control = Q.build_interpolation_matrix(Q.V_control)
+    A_higher_order = inner_t(Q).A
+    assert (A_higher_order - A).norm() < 1e-12
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/test_bspline_control_space.py
+++ b/tests/test_bspline_control_space.py
@@ -9,7 +9,11 @@ import fireshape as fs
                                      fs.LaplaceInnerProduct])
 @pytest.mark.parametrize("order", [2, 3])
 def test_bspline_control_space(dim, inner_t, order, pytestconfig):
-    """ Test template for fs.BsplineControlSpace."""
+    """
+    Test template for fs.BsplineControlSpace.
+    Verify that inner products of B-splines are assembled exactly and finite
+    elements of minimal order are used.
+    """
 
     if dim == 2:
         mesh = fs.DiskMesh(0.1)
@@ -33,6 +37,7 @@ def test_bspline_control_space(dim, inner_t, order, pytestconfig):
     degree = elem.degree()
     Q.mesh_r = meshloc
 
+    # lower order elements give inexact and thus different results
     if degree > 1:
         Q.V_control = fd.FunctionSpace(
             meshloc, elem.reconstruct(degree=degree-1))
@@ -40,6 +45,7 @@ def test_bspline_control_space(dim, inner_t, order, pytestconfig):
         A_lower_order = inner_t(Q).A
         assert (A_lower_order - A).norm() > 1e-12
 
+    # higher order elements cannot increase precision
     Q.V_control = fd.FunctionSpace(
         meshloc, elem.reconstruct(degree=degree+1))
     Q.I_control = Q.build_interpolation_matrix(Q.V_control)


### PR DESCRIPTION
- The interpolation mesh needs to be compatible with the (unrepeated) knots of B-splines.
- In the discretization of 3D box mesh, the degree of non-tensor product element should be the sum of degrees of one-dimensional B-splines.
- Added a test to check that the inner products are computed exactly and minimal degree finite elements are used.