### PR TITLE
Replace firedrake_adjoint with firedrake.adjoint

### DIFF
--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -208,7 +208,8 @@ class PDEconstrainedObjective(Objective):
                 # in order to do this we need to "record a tape of the forward
                 # solve", pyadjoint will then figure out all necessary
                 # adjoints.
-                import firedrake_adjoint as fda
+                import firedrake.adjoint as fda
+                fda.continue_annotation()
                 tape = fda.get_working_tape()
                 tape.clear_tape()
                 # ensure we are annotating
@@ -281,7 +282,8 @@ class ReducedObjective(ShapeObjective):
                 # in order to do this we need to "record a tape of the forward
                 # solve", pyadjoint will then figure out all necessary
                 # adjoints.
-                import firedrake_adjoint as fda
+                import firedrake.adjoint as fda
+                fda.continue_annotation()
                 tape = fda.get_working_tape()
                 tape.clear_tape()
                 # ensure we are annotating

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 try:
     import firedrake # noqa
-    import firedrake_adjoint # noqa
+    import firedrake.adjoint # noqa
 except ImportError:
     raise Exception("Firedrake needs to be installed and activated. "
                     "Please visit firedrakeproject.org")

--- a/tests/test_L2tracking.py
+++ b/tests/test_L2tracking.py
@@ -17,7 +17,7 @@ def handle_taping():
 @pytest.fixture(autouse=True, scope="function")
 def handle_exit_annotation():
     yield
-    # Since importing firedrake_adjoint modifies a global variable, we need to
+    # Since importing firedrake.adjoint modifies a global variable, we need to
     # pause annotations at the end of the module
     annotate = annotate_tape()
     if annotate:

--- a/tests/test_L2tracking_as_PDEconstrainedObjective.py
+++ b/tests/test_L2tracking_as_PDEconstrainedObjective.py
@@ -16,7 +16,7 @@ def handle_taping():
 @pytest.fixture(autouse=True, scope="function")
 def handle_exit_annotation():
     yield
-    # Since importing firedrake_adjoint modifies a global variable, we need to
+    # Since importing firedrake.adjoint modifies a global variable, we need to
     # pause annotations at the end of the module
     annotate = annotate_tape()
     if annotate:

--- a/tests/test_TimeTracking.py
+++ b/tests/test_TimeTracking.py
@@ -16,7 +16,7 @@ def handle_taping():
 @pytest.fixture(autouse=True, scope="function")
 def handle_exit_annotation():
     yield
-    # Since importing firedrake_adjoint modifies a global variable, we need to
+    # Since importing firedrake.adjoint modifies a global variable, we need to
     # pause annotations at the end of the module
     annotate = annotate_tape()
     if annotate:


### PR DESCRIPTION
Since `setup.py` imports `firedrake_adjoint`, `fireshape` currently doesn't install after the changes in https://github.com/firedrakeproject/firedrake/pull/3062

I've just replaced all occurences of `firedrake_adjoint` and tested on t he [sample notebook](https://colab.research.google.com/github/fem-on-colab/fem-on-colab.github.io/blob/gh-pages/tests/firedrake/test-fireshape.ipynb) I use on my FEM on Colab CI. 