### PR TITLE
Ap/derivatives as cofunctions

### DIFF
--- a/fireshape/boundary_extension.py
+++ b/fireshape/boundary_extension.py
@@ -40,7 +40,10 @@ class ElasticityExtension(object):
         self.ls_ext.solve(out, self.zero_fun)
 
     def solve_homogeneous_adjoint(self, rhs, out):
+        """Elasticity-lift rhs with homogeneous DirichletBC."""
         for i in self.fixed_dims:
+            # not sure this is doing anything, but it looks like
+            # an attempt to set rhs.sub(i) = 0 on fixed dimensions
             temp = rhs.sub(i)
             temp *= 0
         self.ls_adj.solve(out, rhs)

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -751,10 +751,17 @@ class ControlVector(ROL.Vector):
     def plus(self, v):
         vec = self.vec_wo()
         vec += v.vec_ro()
+        if self.cofun is not None:
+            with self.cofun.dat.vec_wo as cofun_vec:
+                with v.cofun.dat.vec_ro as summand_vec:
+                    cofun_vec += summand_vec
 
     def scale(self, alpha):
         vec = self.vec_wo()
         vec *= alpha
+        if self.cofun is not None:
+            with self.cofun.dat.vec_wo as vec:
+                vec *= alpha
 
     def clone(self):
         """

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -392,12 +392,14 @@ class BsplineControlSpace(ControlSpace):
         self.mesh_r = mesh
         element = fd.VectorElement("CG", mesh.ufl_cell(), degree)
         self.V_r = fd.FunctionSpace(self.mesh_r, element)
+        self.V_r_dual = self.V_r.dual()
         X = fd.SpatialCoordinate(self.mesh_r)
         self.id = fd.Function(self.V_r).interpolate(X)
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
         self.mesh_m = fd.Mesh(self.T)
         self.V_m = fd.FunctionSpace(self.mesh_m, element)
+        self.V_m_dual = self.V_m.dual()
 
         assert self.dim == self.mesh_r.geometric_dimension()
 

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -173,9 +173,7 @@ class FeControlSpace(ControlSpace):
             with residual.dat.vec as w:
                 self.Ip.multTranspose(w, out.vec_wo())
         else:
-            with residual.dat.vec as vecres:
-                with out.cofun.dat.vec as vecout:
-                    vecres.copy(vecout)
+            out.cofun.assign(residual)
 
     def interpolate(self, vector, out):
         if self.is_DG:

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -48,7 +48,7 @@ class ControlSpace(object):
         Restrict from self.V_r_dual into ControlSpace
 
         Input:
-        residual: fd.Cofunction, is a variable in the dual of self.V_r_dual
+        residual: fd.Cofunction, is a variable in self.V_r_dual
         out: ControlVector, is a variable in the dual of ControlSpace
              (overwritten with result)
         """
@@ -752,16 +752,13 @@ class ControlVector(ROL.Vector):
         vec = self.vec_wo()
         vec += v.vec_ro()
         if self.cofun is not None:
-            with self.cofun.dat.vec_wo as cofun_vec:
-                with v.cofun.dat.vec_ro as summand_vec:
-                    cofun_vec += summand_vec
+            self.cofun += v.cofun
 
     def scale(self, alpha):
         vec = self.vec_wo()
         vec *= alpha
         if self.cofun is not None:
-            with self.cofun.dat.vec_wo as vec:
-                vec *= alpha
+            self.cofun *= alpha
 
     def clone(self):
         """

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -637,7 +637,6 @@ class BsplineControlSpace(ControlSpace):
             self.FullIFW.multTranspose(w, out.vec_wo())
 
     def interpolate(self, vector, out):
-            # add correction to residual_smoothed
         with out.dat.vec as w:
             self.FullIFW.mult(vector.vec_ro(), w)
 
@@ -704,21 +703,7 @@ class ControlVector(ROL.Vector):
 
     def from_first_derivative(self, fe_deriv):
         if self.boundary_extension is not None:
-            # this could be written more elegantly
-            #residual_smoothed = fe_deriv.copy(deepcopy=True)
-            #V = fe_deriv.ufl_function_space()
-            #p1 = fe_deriv
-            #p1 *= -1
-            #p1_ = fd.Cofunction(V.dual())
-            #with p1.dat.vec as vec_fct:
-            #    with p1_.dat.vec as vec_cofct:
-            #        vec_fct.copy(vec_cofct)
-            #self.boundary_extension.solve_homogeneous_adjoint(
-            #    p1_, residual_smoothed)
-            #residual_smoothed_ = fd.Cofunction(V.dual())
-            #self.boundary_extension.apply_adjoint_action(
-            #    residual_smoothed, residual_smoothed_)
-            #residual_smoothed_ -= p1_
+            # residual_smoothed_ -= p1_
             residual_smoothed = fe_deriv.copy(deepcopy=True)
             # Elasticity-lift -fe_deriv with homogeneous DirBC
             p1 = fe_deriv

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -75,7 +75,6 @@ class ControlSpace(object):
         # Check if the new control is different from the last one.  ROL is
         # sometimes a bit strange in that it calls update on the same value
         # more than once, in that case we don't want to solve the PDE again.
-        #import ipdb; ipdb.set_trace()
         if not hasattr(self, 'lastq') or self.lastq is None:
             self.lastq = q.clone()
             self.lastq.set(q)
@@ -704,7 +703,8 @@ class ControlVector(ROL.Vector):
         if self.boundary_extension is not None:
             if self.controlspace.is_DG:
                 raise NotImplementedError("boundary_extension is not"
-                      +" supported for discontinous meshes")
+                      + " supported for discontinous meshes") # noqa
+
             # deep-copy value of fe_deriv
             residual_smoothed = fe_deriv.copy(deepcopy=True)
             # Elasticity-lift -fe_deriv with homogeneous DirBC

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -702,7 +702,9 @@ class ControlVector(ROL.Vector):
 
     def from_first_derivative(self, fe_deriv):
         if self.boundary_extension is not None:
-            import ipdb; ipdb.set_trace()
+            if self.controlspace.is_DG:
+                raise NotImplementedError("boundary_extension is not"
+                      +" supported for discontinous meshes")
             # deep-copy value of fe_deriv
             residual_smoothed = fe_deriv.copy(deepcopy=True)
             # Elasticity-lift -fe_deriv with homogeneous DirBC
@@ -717,9 +719,6 @@ class ControlVector(ROL.Vector):
             # add correction to residual_smoothed
             residual_smoothed -= p1
             self.controlspace.restrict(residual_smoothed, self)
-            #import ipdb; ipdb.set_trace()
-            #rhs_smooth = self.boundary_extension.smoothen_residual(fe_deriv)
-            #self.controlspace.restrict(rhs_smooth, self)
         else:
             self.controlspace.restrict(fe_deriv, self)
 

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -701,7 +701,7 @@ class ControlVector(ROL.Vector):
 
     def from_first_derivative(self, fe_deriv):
         if self.boundary_extension is not None:
-            if self.controlspace.is_DG:
+            if getattr(self.controlspace, "is_DG", False):
                 raise NotImplementedError("boundary_extension is not"
                       + " supported for discontinous meshes") # noqa
 

--- a/fireshape/innerproduct.py
+++ b/fireshape/innerproduct.py
@@ -167,11 +167,11 @@ class UflInnerProduct(InnerProduct):
             # this is a quick fix, the concept of cofunction
             # should be applied throught fireshpae wheneve we
             # evaluate the shape derivative
-            v_ = fd.Cofunction(v.fun.ufl_function_space().dual())
-            with v.fun.dat.vec as vec_fct:
-                with v_.dat.vec as vec_cofct:
-                    vec_fct.copy(vec_cofct)
-            self.ls.solve(out.fun, v_)
+            #v_ = fd.Cofunction(v.fun.ufl_function_space().dual())
+            #with v.fun.dat.vec as vec_fct:
+            #    with v_.dat.vec as vec_cofct:
+            #        vec_fct.copy(vec_cofct)
+            self.ls.solve(out.fun, v.cofun)
 
 
 class H1InnerProduct(UflInnerProduct):

--- a/fireshape/innerproduct.py
+++ b/fireshape/innerproduct.py
@@ -164,13 +164,6 @@ class UflInnerProduct(InnerProduct):
         if self.interpolated:
             self.Aksp.solve(v.vec_ro(), out.vec_wo())
         else:
-            # this is a quick fix, the concept of cofunction
-            # should be applied throught fireshpae wheneve we
-            # evaluate the shape derivative
-            #v_ = fd.Cofunction(v.fun.ufl_function_space().dual())
-            #with v.fun.dat.vec as vec_fct:
-            #    with v_.dat.vec as vec_cofct:
-            #        vec_fct.copy(vec_cofct)
             self.ls.solve(out.fun, v.cofun)
 
 

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -201,7 +201,13 @@ class PDEconstrainedObjective(Objective):
         """
         Get the derivative from pyadjoint.
         """
-        out.from_first_derivative(self.Jred.derivative())
+        dJ = self.Jred.derivative()
+        # Pyadjoint returns a function instead of a cofunction
+        # because it assumes it is computing the gradient
+        with dJ.dat.vec as vec_dJ:
+            with self.deriv_r.dat.vec as vec_r:
+                vec_dJ.copy(vec_r)
+        out.from_first_derivative(self.deriv_r)
 
     def update(self, x, flag, iteration):
         """Update domain and solution to state and adjoint equation."""
@@ -274,8 +280,13 @@ class ReducedObjective(ShapeObjective):
         """
         Get the derivative from pyadjoint.
         """
-
-        out.from_first_derivative(self.Jred.derivative())
+        dJ = self.Jred.derivative()
+        # Pyadjoint returns a function instead of a cofunction
+        # because it assumes it is computing the gradient
+        with dJ.dat.vec as vec_dJ:
+            with self.deriv_r.dat.vec as vec_r:
+                vec_dJ.copy(vec_r)
+        out.from_first_derivative(self.deriv_r)
 
     def update(self, x, flag, iteration):
         """Update domain and solution to state and adjoint equation."""

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -87,10 +87,9 @@ class ShapeObjective(Objective):
         Construct a shape functional.
 
         Preallocate vectors for directional derivatives with respect to
-        perturbations in self.V_m, for their clone on self.V_r, and for
-        the directional derivative wrt perturbations in ControlSpace (so
-        that they are not created every time the derivative is evaluated).
-        Note that self.deriv_r is updated whenever self.deriv_m is.
+        perturbations in self.V_m so that they are not created every time
+        the derivative is evaluated (the same is done for the counterpart
+        in self.V_r_dual in Objective.__init__).
         """
         super().__init__(*args, **kwargs)
         self.deriv_m = fd.Cofunction(self.V_m_dual)
@@ -100,7 +99,7 @@ class ShapeObjective(Objective):
         Assemble partial directional derivative wrt ControlSpace perturbations.
 
         First, assemble directional derivative (wrt FEspace V_m) and
-        store it in self.deriv_m. This automatically updates self.deriv_r,
+        store it in self.deriv_m. Then pass the values to self.deriv_r,
         which is then converted to the directional derivative wrt
         ControlSpace perturbations using ControlSpace.restrict .
         """

--- a/tests/test_levelset.py
+++ b/tests/test_levelset.py
@@ -74,11 +74,10 @@ def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
 
     if use_extension == "w_ext":
         ext = fs.ElasticityExtension(Q.V_r)
-    if use_extension == "w_ext_fixed_dim":
+    elif use_extension == "w_ext_fixed_dim":
         ext = fs.ElasticityExtension(Q.V_r, fixed_dims=[0])
     else:
         ext = None
-
     q = fs.ControlVector(Q, inner, boundary_extension=ext)
 
     """

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -11,7 +11,7 @@ import numpy as np
                                      fs.ElasticityInnerProduct,
                                      fs.LaplaceInnerProduct])
 @pytest.mark.parametrize("use_extension", ["wo_ext", "w_ext",
-                                           "w_ext_fixed_fim"])
+                                           "w_ext_fixed_dim"])
 def test_periodic(dim, inner_t, use_extension, pytestconfig):
     verbose = pytestconfig.getoption("verbose")
     """ Test template for PeriodicControlSpace."""
@@ -75,7 +75,7 @@ def test_periodic(dim, inner_t, use_extension, pytestconfig):
 
     if use_extension == "w_ext":
         ext = fs.ElasticityExtension(Q.V_r)
-    if use_extension == "w_ext_fixed_dim":
+    elif use_extension == "w_ext_fixed_dim":
         ext = fs.ElasticityExtension(Q.V_r, fixed_dims=[0])
     else:
         ext = None

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -10,9 +10,7 @@ import numpy as np
 @pytest.mark.parametrize("inner_t", [fs.H1InnerProduct,
                                      fs.ElasticityInnerProduct,
                                      fs.LaplaceInnerProduct])
-@pytest.mark.parametrize("use_extension", ["wo_ext", "w_ext",
-                                           "w_ext_fixed_dim"])
-def test_periodic(dim, inner_t, use_extension, pytestconfig):
+def test_periodic(dim, inner_t, pytestconfig):
     verbose = pytestconfig.getoption("verbose")
     """ Test template for PeriodicControlSpace."""
 
@@ -72,15 +70,7 @@ def test_periodic(dim, inner_t, use_extension, pytestconfig):
     else:
         cb = None
     J = LevelsetFct(sigma, f, Q, cb=cb)
-
-    if use_extension == "w_ext":
-        ext = fs.ElasticityExtension(Q.V_r)
-    elif use_extension == "w_ext_fixed_dim":
-        ext = fs.ElasticityExtension(Q.V_r, fixed_dims=[0])
-    else:
-        ext = None
-
-    q = fs.ControlVector(Q, inner, boundary_extension=ext)
+    q = fs.ControlVector(Q, inner)
 
     """
     move mesh a bit to check that we are not doing the

--- a/tests/test_volumeconstraint.py
+++ b/tests/test_volumeconstraint.py
@@ -75,7 +75,7 @@ def test_levelset(dim, inner_t, controlspace_t, use_extension, pytestconfig):
 
     if use_extension == "w_ext":
         ext = fs.ElasticityExtension(Q.V_r)
-    if use_extension == "w_ext_fixed_dim":
+    elif use_extension == "w_ext_fixed_dim":
         ext = fs.ElasticityExtension(Q.V_r, fixed_dims=[0])
     else:
         ext = None


### PR DESCRIPTION
Use firedrake cofunction functionality to distinguish between derivative and gradiens when using controlspace of UFL type.