### PR TITLE
Small fixes for new Firedrake containers

### DIFF
--- a/docker/Dockerfile.firedrake4tests
+++ b/docker/Dockerfile.firedrake4tests
@@ -3,7 +3,7 @@ FROM firedrakeproject/firedrake-vanilla-default:latest
 
 MAINTAINER Alberto Paganini <admp1@le.ac.uk>
 
-RUN sudo apt-get update \
-    && sudo apt-get -y dist-upgrade \
-    && sudo apt-get -y install gmsh \
-    && sudo rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get -y dist-upgrade \
+    && apt-get -y install gmsh \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.fireshape
+++ b/docker/Dockerfile.fireshape
@@ -3,12 +3,12 @@ FROM firedrakeproject/firedrake:latest
 
 MAINTAINER Alberto Paganini <admp1@le.ac.uk>
 
-RUN sudo apt-get update \
-    && sudo apt-get -y dist-upgrade \
-    && sudo apt-get -y install gmsh \
-    && sudo rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get -y dist-upgrade \
+    && apt-get -y install gmsh \
+    && rm -rf /var/lib/apt/lists/*
 
 # Now install fireshape
-RUN pip install --break-system-packages --verbose --src . \
+RUN pip install --verbose --src /opt \
         --editable git+https://github.com/fireshape/fireshape.git#egg=fireshape
 


### PR DESCRIPTION
This puts fireshape into `/opt` which is consistent with all the other Firedrake packages in `firedrakeproject/firedrake:latest`.