### PR TITLE
Make fireshape compatible with current firedrake's release

### DIFF
--- a/examples/L2tracking/L2tracking_main.py
+++ b/examples/L2tracking/L2tracking_main.py
@@ -16,7 +16,7 @@ e = PoissonSolver(mesh_m)
 
 # save state variable evolution in file u.pvd
 e.solve()
-out = fd.File("u.pvd")
+out = fd.VTKFile("u.pvd")
 
 # create PDEconstrained objective functional
 J_ = L2trackingObjective(e, Q, cb=lambda: out.write(e.solution))

--- a/examples/levelset/levelset_spline.py
+++ b/examples/levelset/levelset_spline.py
@@ -17,7 +17,7 @@ mesh_m = Q.mesh_m
 (x, y) = fd.SpatialCoordinate(mesh_m)
 
 f = (pow(x, 2))+pow(2*y, 2) - 1
-outdef = fd.File("deformation.pvd")
+outdef = fd.VTKFile("deformation.pvd")
 out = fd.File("domain.pvd")
 V, IM = Q.get_space_for_inner()
 T = fd.Function(V)

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -159,7 +159,7 @@ class FeControlSpace(ControlSpace):
 
         # Create self.id and self.T, self.mesh_m, and self.V_m.
         X = fd.SpatialCoordinate(self.mesh_r)
-        self.id = fd.assemble(interpolate(X, self.V_r))
+        self.id = fd.assemble(fd.interpolate(X, self.V_r))
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
         self.mesh_m = fd.Mesh(self.T)
@@ -175,15 +175,15 @@ class FeControlSpace(ControlSpace):
             self.V_c_dual = self.V_c.dual()
             testfct_V_c = fd.TestFunction(self.V_c)
             # Create interpolator from V_c into V_r
-            self.Ip = Interpolator(testfct_V_c, self.V_r,
-                                   allow_missing_dofs=True)
+            self.Ip = fd.Interpolator(testfct_V_c, self.V_r,
+                                      allow_missing_dofs=True)
         elif element.family() == 'Discontinuous Lagrange':
             self.is_DG = True
             self.V_c = fd.VectorFunctionSpace(self.mesh_r, "CG", degree)
             self.V_c_dual = self.V_c.dual()
             testfct_V_c = fd.TestFunction(self.V_c)
             # Create interpolator from V_c into V_r
-            self.Ip = Interpolator(testfct_V_c, self.V_r)
+            self.Ip = fd.Interpolator(testfct_V_c, self.V_r)
 
     def restrict(self, residual, out):
         if getattr(self, "is_DG", False):
@@ -563,7 +563,7 @@ class BsplineControlSpace(ControlSpace):
         # by replacing x_fct with self.id
         x_fct = fd.SpatialCoordinate(self.mesh_r)  # used for x_int
         # compute self.M, x_int will be overwritten below
-        x_int = fd.assemble(interpolate(x_fct[0], V.sub(0)))
+        x_int = fd.assemble(fd.interpolate(x_fct[0], V.sub(0)))
         self.M = x_int.vector().size()
 
         comm = self.comm
@@ -587,7 +587,7 @@ class BsplineControlSpace(ControlSpace):
             IM.setSizes(((lsize, gsize), (local_n, n)))
 
             IM.setUp()
-            x_int = fd.assemble(interpolate(x_fct[dim], V.sub(0)))
+            x_int = fd.assemble(fd.interpolate(x_fct[dim], V.sub(0)))
             x = x_int.vector().get_local()
             for idx in range(n):
                 coeffs = np.zeros(knots.shape, dtype=float)

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -564,7 +564,7 @@ class BsplineControlSpace(ControlSpace):
         x_fct = fd.SpatialCoordinate(self.mesh_r)  # used for x_int
         # compute self.M, x_int will be overwritten below
         x_int = fd.assemble(fd.interpolate(x_fct[0], V.sub(0)))
-        self.M = x_int.vector().size()
+        self.M = x_int.dat.dataset.layout_vec.size
 
         comm = self.comm
 
@@ -582,13 +582,13 @@ class BsplineControlSpace(ControlSpace):
             local_n = n // comm.size + int(comm.rank < (n % comm.size))
             IM = PETSc.Mat().create(comm=self.comm)
             IM.setType(PETSc.Mat.Type.AIJ)
-            lsize = x_int.vector().local_size()
-            gsize = x_int.vector().size()
+            lsize = x_int.dat.data_ro.size
+            gsize = x_int.dataset.layout_vec.size
             IM.setSizes(((lsize, gsize), (local_n, n)))
 
             IM.setUp()
             x_int = fd.assemble(fd.interpolate(x_fct[dim], V.sub(0)))
-            x = x_int.vector().get_local()
+            x = x_int.dat.data_ro
             for idx in range(n):
                 coeffs = np.zeros(knots.shape, dtype=float)
 

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -176,11 +176,13 @@ class FeControlSpace(ControlSpace):
             # Create interpolator and cointerpolator from V_c into V_r
             self.Ip_v = fd.Function(self.V_c)
             interp = fd.interpolate(self.Ip_v, self.V_r,
-                                    allow_missing_dofs=True, default_missing_val=0.)
+                                    allow_missing_dofs=True,
+                                    default_missing_val=0.)
             self.Ip = fd.Interpolator(interp, self.V_r)
             self.CoIp_wstar = fd.Cofunction(self.V_r.dual())
             restr = fd.interpolate(fd.TestFunction(self.V_c), self.CoIp_wstar,
-                                   allow_missing_dofs=True, default_missing_val=0.)
+                                   allow_missing_dofs=True,
+                                   default_missing_val=0.)
             self.CoIp = fd.Interpolator(restr, self.V_r)
 
         elif element.family() == 'Discontinuous Lagrange':

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -176,14 +176,14 @@ class FeControlSpace(ControlSpace):
             # Create interpolator and cointerpolator from V_c into V_r
             self.Ip_v = fd.Function(self.V_c)
             interp = fd.interpolate(self.Ip_v, self.V_r,
-                                    allow_missing_dofs=True,
                                     default_missing_val=0.)
-            self.Ip = fd.Interpolator(interp, self.V_r)
+            self.Ip = fd.Interpolator(interp, self.V_r,
+                                      allow_missing_dofs=True)
             self.CoIp_wstar = fd.Cofunction(self.V_r.dual())
             restr = fd.interpolate(fd.TestFunction(self.V_c), self.CoIp_wstar,
-                                   allow_missing_dofs=True,
                                    default_missing_val=0.)
-            self.CoIp = fd.Interpolator(restr, self.V_r)
+            self.CoIp = fd.Interpolator(restr, self.V_r,
+                                        allow_missing_dofs=True)
 
         elif element.family() == 'Discontinuous Lagrange':
             self.is_DG = True

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -583,7 +583,7 @@ class BsplineControlSpace(ControlSpace):
             IM = PETSc.Mat().create(comm=self.comm)
             IM.setType(PETSc.Mat.Type.AIJ)
             lsize = x_int.dat.data_ro.size
-            gsize = x_int.dataset.layout_vec.size
+            gsize = x_int.dat.dataset.layout_vec.size
             IM.setSizes(((lsize, gsize), (local_n, n)))
 
             IM.setUp()

--- a/fireshape/control.py
+++ b/fireshape/control.py
@@ -1,8 +1,6 @@
 from .innerproduct import InnerProduct
 import ROL
 import firedrake as fd
-from firedrake.__future__ import interpolate as fd_interpolate
-from firedrake.__future__ import Interpolator as fd_Interpolator
 
 __all__ = ["FeControlSpace", "FeMultiGridControlSpace",
            "BsplineControlSpace", "ControlVector"]
@@ -161,7 +159,7 @@ class FeControlSpace(ControlSpace):
 
         # Create self.id and self.T, self.mesh_m, and self.V_m.
         X = fd.SpatialCoordinate(self.mesh_r)
-        self.id = fd.assemble(fd_interpolate(X, self.V_r))
+        self.id = fd.assemble(interpolate(X, self.V_r))
         self.T = fd.Function(self.V_r, name="T")
         self.T.assign(self.id)
         self.mesh_m = fd.Mesh(self.T)
@@ -177,15 +175,15 @@ class FeControlSpace(ControlSpace):
             self.V_c_dual = self.V_c.dual()
             testfct_V_c = fd.TestFunction(self.V_c)
             # Create interpolator from V_c into V_r
-            self.Ip = fd_Interpolator(testfct_V_c, self.V_r,
-                                      allow_missing_dofs=True)
+            self.Ip = Interpolator(testfct_V_c, self.V_r,
+                                   allow_missing_dofs=True)
         elif element.family() == 'Discontinuous Lagrange':
             self.is_DG = True
             self.V_c = fd.VectorFunctionSpace(self.mesh_r, "CG", degree)
             self.V_c_dual = self.V_c.dual()
             testfct_V_c = fd.TestFunction(self.V_c)
             # Create interpolator from V_c into V_r
-            self.Ip = fd_Interpolator(testfct_V_c, self.V_r)
+            self.Ip = Interpolator(testfct_V_c, self.V_r)
 
     def restrict(self, residual, out):
         if getattr(self, "is_DG", False):
@@ -565,7 +563,7 @@ class BsplineControlSpace(ControlSpace):
         # by replacing x_fct with self.id
         x_fct = fd.SpatialCoordinate(self.mesh_r)  # used for x_int
         # compute self.M, x_int will be overwritten below
-        x_int = fd.assemble(fd_interpolate(x_fct[0], V.sub(0)))
+        x_int = fd.assemble(interpolate(x_fct[0], V.sub(0)))
         self.M = x_int.vector().size()
 
         comm = self.comm
@@ -589,7 +587,7 @@ class BsplineControlSpace(ControlSpace):
             IM.setSizes(((lsize, gsize), (local_n, n)))
 
             IM.setUp()
-            x_int = fd.assemble(fd_interpolate(x_fct[dim], V.sub(0)))
+            x_int = fd.assemble(interpolate(x_fct[dim], V.sub(0)))
             x = x_int.vector().get_local()
             for idx in range(n):
                 coeffs = np.zeros(knots.shape, dtype=float)

--- a/fireshape/innerproduct.py
+++ b/fireshape/innerproduct.py
@@ -302,7 +302,7 @@ class SurfaceInnerProduct(InnerProduct):
         A = A.petscmat
         tdim = V.mesh().topological_dimension()
 
-        lsize = fd.Function(V).vector().local_size()
+        lsize = fd.Function(V).dat.data_ro.size
 
         def get_nodes_bc(bc):
             nodes = bc.nodes

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -190,7 +190,7 @@ class PDEconstrainedObjective(Objective):
         Raise an error if the mesh is tangled.
         """
         self.detDT.interpolate(fd.det(fd.grad(self.Q.T)))
-        assert (min(self.detDT.vector()) > 0.05)
+        assert (min(self.detDT.dat.data_ro) > 0.05)
 
     def objective_value(self):
         """

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -296,8 +296,7 @@ class ReducedObjective(ShapeObjective):
         """
         Get the derivative from pyadjoint.
         """
-        opts = {"riesz_representation": None}
-        dJ = self.Jred.derivative(options=opts)
+        dJ = self.Jred.derivative()
         # transplant from moved to reference mesh
         with dJ.dat.vec as vec_dJ:
             with self.deriv_r.dat.vec as vec_r:

--- a/fireshape/objective.py
+++ b/fireshape/objective.py
@@ -229,8 +229,7 @@ class PDEconstrainedObjective(Objective):
             self.createJred()
             self.value(None, None)
         if self.feasible_control:
-            opts = {"riesz_representation": None}
-            dJ = self.Jred.derivative(options=opts)
+            dJ = self.Jred.derivative()
             # transplant from moved to reference mesh
             with dJ.dat.vec as vec_dJ:
                 with self.deriv_r.dat.vec as vec_r:

--- a/fireshape/zoo/box_constraint.py
+++ b/fireshape/zoo/box_constraint.py
@@ -28,12 +28,10 @@ class MoYoBoxConstraint(fs.DeformationObjective):
 
     def value_form(self):
         lam = self.lam
-        # lamv = lam.vector()
         c = self.c
         psi = self.upper_bound
         phi = self.lower_bound
         T = self.T
-        # Tv = T.vector()
         temp0 = Max(lam[0] + c*(T[0]-psi[0]), fd.Constant(0.0)) \
             + Min(lam[0] + c*(T[0]-phi[0]), fd.Constant(0.0))
         temp1 = Max(lam[1] + c*(T[1]-psi[1]), fd.Constant(0.0)) \

--- a/tests/test_box_constraints.py
+++ b/tests/test_box_constraints.py
@@ -72,7 +72,7 @@ def test_box_constraint(pytestconfig):
     problem = ROL.OptimizationProblem(J, q)
     solver = ROL.OptimizationSolver(problem, params)
     solver.solve()
-    Tvec = Q.T.vector()
+    Tvec = Q.T.dat.data_ro
     nodes = fd.DirichletBC(Q.V_r, fd.Constant((0.0, 0.0)), [2]).nodes
     assert np.all(Tvec[nodes, 0] <= 1.3 + 1e-4)
     assert np.all(Tvec[nodes, 1] <= 0.9 + 1e-4)
@@ -151,7 +151,7 @@ def test_objective_plus_box_constraint(pytestconfig):
     problem = ROL.OptimizationProblem(J, q)
     solver = ROL.OptimizationSolver(problem, params)
     solver.solve()
-    Tvec = Q.T.vector()
+    Tvec = Q.T.dat.data_ro
     nodes = fd.DirichletBC(Q.V_r, fd.Constant((0.0, 0.0)), [2]).nodes
     assert np.all(Tvec[nodes, 0] <= 1.2 + 1e-1)
     assert np.all(Tvec[nodes, 1] <= 1.2 + 1e-1)

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -55,7 +55,7 @@ def test_periodic(dim, inner_t, pytestconfig):
         def value_form(self):
             # volume integral
             self.detDT.interpolate(fd.det(fd.grad(self.Q.T)))
-            if min(self.detDT.vector()) > 0.05:
+            if min(self.detDT.dat.data_ro) > 0.05:
                 integrand = (self.sigma - self.f)**2
             else:
                 integrand = np.nan*(self.sigma - self.f)**2

--- a/tests/test_spectral_constraint.py
+++ b/tests/test_spectral_constraint.py
@@ -55,7 +55,7 @@ def test_spectral_constraint(pytestconfig):
     problem = ROL.OptimizationProblem(J, q)
     solver = ROL.OptimizationSolver(problem, params)
     solver.solve()
-    Tvec = Q.T.vector()[:, :]
+    Tvec = Q.T.dat.data_ro
     for i in range(Tvec.shape[0]):
         assert abs(Tvec[i, 0]) < 0.55 + 1e-4
         assert abs(Tvec[i, 1]) < 0.55 + 1e-4


### PR DESCRIPTION
1. replace .vector() with .dat.data
2. do not import interpolate from future any longer
3. use new Interpolator API